### PR TITLE
pycharm compat tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+current dev branch
+
+### Added
+
+- added this changelog
+
+ 
+### Fixed
+
+
+
+### Changed
+
+- remove relative imports everywhere
+    - improves readability
+    - removes dependency on work_dir (allows to run directly from pycharm)
+    
+    
+- mycroft.conf
+    - change data_dir to ~/mycroft_data
+    - allow to easily run code without worrying about permissions
+   
+## [mycroft-16jan2020]
+
+Forked from mycroft
+
+[unreleased]: https://github.com/NeonJarbas/NeonCore/tree/dev
+[mycroft-16jan2020]: https://github.com/NeonJarbas/NeonCore/tree/mycroft/16/01/2020

--- a/mycroft/audio/__main__.py
+++ b/mycroft/audio/__main__.py
@@ -24,7 +24,7 @@ from mycroft.util import reset_sigint_handler, wait_for_exit_signal, \
 from mycroft.util.log import LOG
 
 import mycroft.audio.speech as speech
-from .audioservice import AudioService
+from mycroft.audio.audioservice import AudioService
 
 
 def main():

--- a/mycroft/client/text/__main__.py
+++ b/mycroft/client/text/__main__.py
@@ -18,7 +18,7 @@ import io
 import os.path
 import curses
 from mycroft.util import get_ipc_directory
-from .text_client import (
+from mycroft.client.text.text_client import (
         load_settings, save_settings, simple_cli, gui_main,
         start_log_monitor, start_mic_monitor, connect_to_mycroft,
         ctrl_c_handler

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -90,7 +90,7 @@
   },
 
   // Also change in scripts/prepare-msm.sh
-  "data_dir": "/opt/mycroft",
+  "data_dir": "~/mycroft_data",
 
   // General skill values
   "skills": {

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -40,11 +40,11 @@ from mycroft.util import (
 )
 from mycroft.util.lang import set_active_lang
 from mycroft.util.log import LOG
-from .core import FallbackSkill
-from .event_scheduler import EventScheduler
-from .intent_service import IntentService
-from .padatious_service import PadatiousService
-from .skill_manager import SkillManager
+from mycroft.skills.core import FallbackSkill
+from mycroft.skills.event_scheduler import EventScheduler
+from mycroft.skills.intent_service import IntentService
+from mycroft.skills.padatious_service import PadatiousService
+from mycroft.skills.skill_manager import SkillManager
 
 RASPBERRY_PI_PLATFORMS = ('mycroft_mark_1', 'picroft', 'mycroft_mark_2pi')
 

--- a/mycroft/skills/mycroft_skill/event_container.py
+++ b/mycroft/skills/mycroft_skill/event_container.py
@@ -4,7 +4,7 @@ from mycroft.messagebus.message import Message
 from mycroft.metrics import Stopwatch, report_timing
 from mycroft.util.log import LOG
 
-from ..skill_data import to_alnum
+from mycroft.skills.skill_data import to_alnum
 
 
 def unmunge_message(message, skill_id):


### PR DESCRIPTION
### Added

- added changelog
 
### Changed

- remove relative imports everywhere
    - improves readability (explicit paths)
    - removes dependency on work_dir (allows to run directly from pycharm)
    
- mycroft.conf
    - change data_dir to ~/mycroft_data
    - allow to easily run code without worrying about permissions