### PR TITLE
don't cast self.token to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ current dev branch
  
 ### Fixed
 
+- stt
+    - don't cast self.token to string
+        - google stt - default to package free key instead of throwing error
 
 
 ### Changed

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -52,7 +52,7 @@ class STT(metaclass=ABCMeta):
 class TokenSTT(STT, metaclass=ABCMeta):
     def __init__(self):
         super(TokenSTT, self).__init__()
-        self.token = str(self.credential.get("token"))
+        self.token = self.credential.get("token")
 
 
 class GoogleJsonSTT(STT, metaclass=ABCMeta):


### PR DESCRIPTION
together with #2 this makes STT just work even if backend is disabled

### Fixed

- stt
    - don't cast self.token to string
        - google stt - default to package free key instead of throwing error

