### PR TITLE
make vlc the default backend

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -440,7 +440,7 @@
         "duck": true
       }
     },
-    "default-backend": "local"
+    "default-backend": "vlc"
   },
 
   "Display": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ padaos==0.1.9
 precise-runner==0.2.1
 petact==0.1.2
 
+vlc
 
 jarbas_utils==0.4.1
 fastlang


### PR DESCRIPTION
makes vlc the default audio backend

this is the most feature rich and the only that supports https streams correctly

minor change, but makes the end user experience much better in general