### PR TITLE
use precise 0.3

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -284,7 +284,7 @@
 
   // Settings used for any precise wake words
   "precise": {
-    "dist_url": "https://github.com/MycroftAI/precise-data/raw/dist/{arch}/latest",
+    "dist_url": "https://github.com/MycroftAI/precise-data/raw/dist/{arch}/latest-dev",
     "model_url": "https://raw.githubusercontent.com/MycroftAI/precise-data/models/{wake_word}.tar.gz"
   },
 


### PR DESCRIPTION
hey neon model was trained with precise 0.3, but .conf is pointing to 0.2 binary

this make the default wake word work again

NOTE: this is temporary, precise should also be moved into a proper plugin, since i doubt mycroft will do a good job with this i think ill just make the plugin myself instead of waiting for them.... a good precise plugin should support both v0.2 and v0.3 models, mycroft will ignore this but we support multiple wake word and need it