### PR TITLE
fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,8 @@
-six==1.13.0
 requests==2.20.0
-gTTS==2.0.4
+gTTS>=2.2.1
 PyAudio==0.2.11
-pyee==5.0.0
 SpeechRecognition==3.8.1
 tornado==6.0.3
-websocket-client==0.54.0
 requests-futures==0.9.5
 pyalsaaudio==0.8.2
 xmlrunner==1.7.7
@@ -15,25 +12,23 @@ pocketsphinx==0.1.15
 inflection==0.3.1
 pillow==6.2.1
 python-dateutil==2.6.0
-pychromecast==3.2.2
 python-vlc==1.1.2
 google-api-python-client==1.6.4
 fasteners==0.14.1
 PyYAML==5.1.2
-
-adapt-parser==0.3.4
-padatious==0.4.6
+mycroft-messagebus-client>=0.8.4
+adapt-parser==0.3.7
+padatious==0.4.8
 fann2==1.0.7
-padaos==0.1.9
 precise-runner==0.2.1
 petact==0.1.2
 
 
-ovos_utils>=0.0.2
+ovos_utils>=0.0.5
 fastlang
-#langdetect #  optional, lang detection module
-#pycld2 # optional, lang detection module
-#pycld3 # optional, lang detection module
+langdetect #  optional, lang detection module
+pycld2 # optional, lang detection module
+pycld3 # optional, lang detection module
 
 boto3
 numpy


### PR DESCRIPTION
- there was an extra "vlc" in requirements.txt that caused install to fail (correct package is python-vlc and is already in requirements.txt)
- bumped adapt version for compatibility with latest pyee
- bumped mycroft-messagebus, version 0.8.3 is broken on pip
- removed requirements included in others (eg, pyee and websocket client are installed by mycroft-messagebus)
- bumped GTTS which was using a borked version
- removed pychromecast which is not used by core (belongs in plugin, relates to #40 )
- bumped padatious
- bumped ovos_utils
