### PR TITLE
feat/converse_signature

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -372,7 +372,7 @@ class MycroftSkill(OldNeonCompatibilitySkill):
         """
         return None
 
-    def converse(self, message=None):
+    def converse(self, message):
         """Handle conversation.
 
         This method gets a peek at utterances before the normal intent
@@ -396,7 +396,8 @@ class MycroftSkill(OldNeonCompatibilitySkill):
         Returns:
             str: user's response or None on a timeout
         """
-        def converse(utterances, lang=None):
+        def converse(message):
+            utterances = message.data["utterances"]
             converse.response = utterances[0] if utterances else None
             converse.finished = True
             return True

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -298,14 +298,10 @@ class SkillManager(Thread):
                         # new common style, 1 arg
                         if len(signature(converse_method).parameters) == 1:
                             handled = skill_loader.instance.converse(message)
-                        # mycroft style, 2 args
+                        # old mycroft style, 2 args
                         elif len(signature(converse_method).parameters) == 2:
                             handled = skill_loader.instance.converse(utterances,
                                                                      lang)
-                        # old neon style, 3 args
-                        elif len(signature(converse_method).parameters) == 3:
-                            handled = skill_loader.instance.converse(utterances,
-                                                                     lang, message)
                         # unrecognized signature
                         else:
                             raise ValueError("Arguments don't match function signature")


### PR DESCRIPTION
adds `converse` method support for all skill formats

- old Mycroft skills expect `utterances, lang` as arguments
- old Neon skills expect `utterances, lang, message` as arguments
- new style skills expect `message` as arguments


relates to https://github.com/MycroftAI/mycroft-core/issues/2812

