### PR TITLE
Add timing metrics for Neon Testing

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -337,6 +337,12 @@ class IntentService:
             utterances = message.data.get('utterances', [])
 
             message.context = message.context or {}
+            # Add or init timing data
+            if not message.context.get("timing"):
+                LOG.warning("No timing data available at intent service")
+                message.context["timing"] = {}
+            message.context["timing"]["transcribed"] = message.context.get("timing", {}).get("transcribed", time.time())
+
             # pipe utterance trough parsers to get extra metadata
             # use cases: translation, emotion_data, keyword spotting etc.
             # parsers are ordered by priority
@@ -374,7 +380,7 @@ class IntentService:
             with stopwatch:
                 # Give active skills an opportunity to handle the utterance
                 converse = self._converse(combined, lang, message)
-
+                message.context["timing"]["check_converse"] = stopwatch.time
                 if not converse:
                     # No conversation, use intent system to handle utterance
                     intent = self._adapt_intent_match(utterances,

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1274,9 +1274,14 @@ class MycroftSkill(OldNeonCompatibilitySkill):
             "was_translated": detected_lang == self.language_config["user"].split("-")[0],
             "raw_utterance": original
         }
+        message.context.get("timing", {})["speech_start"] = time.time()
 
-        m = message.forward("speak", data) if message else Message("speak", data)
-        self.bus.emit(m)
+        message_to_speech = message.forward("speak", data) if message else Message("speak", data)
+
+        if not message_to_speech.context.get("timing"):
+            message_to_speech.context["timing"] = {}
+        message_to_speech.context["timing"]["speech_start"] = time.time()
+        self.bus.emit(message_to_speech)
 
         if wait:
             wait_while_speaking()


### PR DESCRIPTION
Adds 'timing' context for intent matching, skill speech, audio output. Testing is completed by https://github.com/NeonGeckoCom/neon-test-utils. Timing will also used for metrics reporting for stt/tts/intent match/intent handling

Supersedes #68 

## Changelog
Added timing context in intent_service.py and mycroft_skill.py
Add ident to begin_audio and end_audio in tts for test util
