### PR TITLE
Prevent bootstrapping on auth (major slowdown)

### DIFF
--- a/mycroft/skills/skill_store.py
+++ b/mycroft/skills/skill_store.py
@@ -152,9 +152,9 @@ class SkillsStore:
         neon = self.osm.get_appstore("neon")
         neon_token = self.config.get("neon_token")
         if neon_token:
-            neon.authenticate(neon_token)
+            neon.authenticate(neon_token, False)
         else:
-            neon.authenticate()
+            neon.authenticate(bootstrap=False)
 
     def deauthenticate_neon(self):
         neon = self.osm.get_appstore("neon")


### PR DESCRIPTION
Remove bootstrap call in authenticate_neon. Bootstrapping should happen on init/search anyways; this call forces hitting GitHub on every skill update check/install.
