### PR TITLE
Catch and handle skill installation errors

### DIFF
--- a/neon_core/skills/skill_store.py
+++ b/neon_core/skills/skill_store.py
@@ -236,6 +236,6 @@ class SkillsStore:
                 updated = self.install_skill(skill, update=update)
             except Exception as e:
                 LOG.error(e)
-                updated = False
+                continue  # Assume install has failed and skill is not installed
             skills.append((skill, updated))
         return skills


### PR DESCRIPTION
Wrap skills install in try/except to prevent single failure from stopping all default skills installing