### PR TITLE
Feat extra requirements

### DIFF
--- a/requirements/client.txt
+++ b/requirements/client.txt
@@ -1,0 +1,1 @@
+neon-client @ git+https://github.com/NeonGeckoCom/neon-core-client

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,2 @@
+neon-test-utils @ git+https://github.com/NeonGeckoCom/neon-test-utils
+neon_cli_client @ git+https://github.com/NeonGeckoCom/neon_cli

--- a/requirements/local_speech_processing.txt
+++ b/requirements/local_speech_processing.txt
@@ -1,0 +1,2 @@
+neon-stt-plugin-deepspeech_stream_local @ git+https://github.com/NeonGeckoCom/neon-stt-plugin-deepspeech_stream_local
+neon-tts-plugin-mozilla_local @ git+https://github.com/NeonGeckoCom/neon-tts-plugin-mozilla_local

--- a/requirements/remote_speech_processing.txt
+++ b/requirements/remote_speech_processing.txt
@@ -1,0 +1,2 @@
+neon-stt-plugin-google_cloud_streaming @ git+https://github.com/NeonGeckoCom/neon-stt-plugin-google_cloud_streaming
+neon-tts-plugin-polly @ git+https://github.com/NeonGeckoCom/neon-tts-plugin-polly

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,8 +3,9 @@ HolmesV[all]>=2021.5.6a13
 mock_msm
 
 # neon stuff
-#git+https://github.com/NeonGeckoCom/neon-skill-utils
-#git+https://github.com/NeonJarbas/neon_speech
+neon_speech @ git+https://github.com/NeonGeckoCom/neon_speech
+neon_audio @ git+https://github.com/NeonGeckoCom/neon_audio
+neon_enclosure @ git+https://github.com/NeonGeckoCom/neon_enclosure
 
 # utils
 rapidfuzz

--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -1,0 +1,1 @@
+neon-core-server @ git+https://github.com/NeonGeckoCom/neon-core-server

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ BASEDIR = os.path.abspath(os.path.dirname(__file__))
 
 def required(requirements_file):
     """ Read requirements file and remove comments and empty lines. """
-    with open(os.path.join(BASEDIR, requirements_file), 'r') as f:
+    with open(os.path.join(BASEDIR, "requirements", requirements_file), 'r') as f:
         requirements = f.read().splitlines()
         return [pkg for pkg in requirements
                 if pkg.strip() and not pkg.startswith("#")]
@@ -35,6 +35,13 @@ setup(
     url='https://github.com/MycroftAI/mycroft-core',
     description='NeonCore',
     install_requires=required('requirements.txt'),
+    extras_require={
+        "client": required("client.txt"),
+        "server": required("server.txt"),
+        "dev": required("dev.txt"),
+        "local": required("local_speech_processing.txt"),
+        "remote": required("remote_speech_processing.txt")
+    },
     packages=find_packages(include=['neon_core*']),
     package_data={'neon_core': ['res/precise_models/*', 'res/snd/*', 'res/text/*/*.voc', 'res/text/*/*.dialog',
                                 'res/ui/*.qml', 'res/ui/*.png', 'res/*', 'configuration/*.conf']


### PR DESCRIPTION
Moves all requirements to a separate `requirements` directory and adds separate sets for:
* client
* server
* dev
* local speech
* remote speech

Common installation would look like: `pip install git+https://github.com/NeonDaniel/NeonCore#egg=neon_core[dev,client,remote]` 
