### PR TITLE
Add missing psutil requirement

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,6 +11,7 @@ neon_enclosure @ git+https://github.com/NeonGeckoCom/neon_enclosure
 # utils
 rapidfuzz
 kthread
+psutil
 ovos_utils>=0.0.10
 ovos-skills-manager>=0.0.2
 


### PR DESCRIPTION
psutil is used in run_neon to handle start/stop of modules but was not included in requirements.txt