### PR TITLE
Add default ipc_path to config

### DIFF
--- a/neon_core/configuration/neon.conf
+++ b/neon_core/configuration/neon.conf
@@ -516,5 +516,6 @@
     "default-backend": "opencv"
   },
 
-  "debug": false
+  "debug": false,
+  "ipc_path": "/tmp/neon/ipc"
 }


### PR DESCRIPTION
Add default value of `/tmp/neon/ipc` for `ipc_path`