### PR TITLE
Startup bugfixes, annotations, refactoring

### DIFF
--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -38,11 +38,11 @@ NEON_ROOT_PATH = dirname(dirname(__file__))
 
 def setup_ovos_core_config():
     """
-    Runs at module init to ensure base holmes.conf exists to patch ovos-core. Note that this must run before any import
+    Runs at module init to ensure base ovos.conf exists to patch ovos-core. Note that this must run before any import
     of Configuration class.
     """
     OVOS_CONFIG = join(xdg.BaseDirectory.save_config_path("OpenVoiceOS"),
-                         "ovos.conf")
+                       "ovos.conf")
 
     _NEON_OVOS_CONFIG = {
         "module_overrides": {
@@ -67,6 +67,8 @@ def setup_ovos_core_config():
     try:
         with open(OVOS_CONFIG) as f:
             cfg = json.load(f)
+    except FileNotFoundError:
+        pass
     except Exception as e:
         LOG.error(e)
 
@@ -77,8 +79,9 @@ def setup_ovos_core_config():
 
 def setup_ovos_config():
     """
-    Configure OVOS config to read from neon.conf files and set this path as the root.
+    Configure ovos_utils to read from neon.conf files and set this path as the root.
     """
+    # TODO: This method will be handled in ovos-core directly in the future
     # ensure ovos_utils can find neon_core
     set_root_path(NEON_ROOT_PATH)
     # make ovos_utils load the proper .conf files

--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -36,15 +36,15 @@ from neon_utils.configuration_utils import write_mycroft_compatible_config
 NEON_ROOT_PATH = dirname(dirname(__file__))
 
 
-def setup_holmes_config():
+def setup_ovos_core_config():
     """
     Runs at module init to ensure base holmes.conf exists to patch ovos-core. Note that this must run before any import
     of Configuration class.
     """
-    HOLMES_CONFIG = join(xdg.BaseDirectory.save_config_path("HolmesV"),
-                         "holmes.conf")
+    OVOS_CONFIG = join(xdg.BaseDirectory.save_config_path("OpenVoiceOS"),
+                         "ovos.conf")
 
-    _NEON_HOLMES_CONFIG = {
+    _NEON_OVOS_CONFIG = {
         "module_overrides": {
             "neon_core": {
                 "xdg": True,
@@ -65,13 +65,13 @@ def setup_holmes_config():
 
     cfg = {}
     try:
-        with open(HOLMES_CONFIG) as f:
+        with open(OVOS_CONFIG) as f:
             cfg = json.load(f)
     except Exception as e:
         LOG.error(e)
 
-    cfg = merge_dict(cfg, _NEON_HOLMES_CONFIG)
-    with open(HOLMES_CONFIG, "w") as f:
+    cfg = merge_dict(cfg, _NEON_OVOS_CONFIG)
+    with open(OVOS_CONFIG, "w") as f:
         json.dump(cfg, f, indent=4, ensure_ascii=True)
 
 
@@ -91,7 +91,7 @@ setup_ovos_config()
 # TODO HolmesV does not yet support yaml configs, once it does
 #  Configuration.get() will be made to load the existing neon config files,
 #  for now it simply provides correct default values
-setup_holmes_config()
+setup_ovos_core_config()
 
 neon_config_path = join(xdg.BaseDirectory.save_config_path("neon"),
                         "neon.conf")

--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -99,6 +99,7 @@ setup_ovos_core_config()
 neon_config_path = join(xdg.BaseDirectory.save_config_path("neon"),
                         "neon.conf")
 write_mycroft_compatible_config(neon_config_path)
+# TODO: Consider when this log is valid/config is changed or not already synced with neon_config DM
 LOG.info(f"{neon_config_path} will be overwritten with Neon YAML config contents.")
 
 # patch version string to allow downstream to know where it is running

--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -22,18 +22,25 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from os.path import join, dirname, exists
+
+from os.path import join, dirname
 import xdg.BaseDirectory
 import json
 from ovos_utils.json_helper import merge_dict
 from ovos_utils.system import set_root_path
 from ovos_utils.configuration import set_config_name
 
+from neon_utils import LOG
+from neon_utils.configuration_utils import write_mycroft_compatible_config
+
 NEON_ROOT_PATH = dirname(dirname(__file__))
 
-# first thing to do is ensure user holmes.conf exists
-# NOTE: must be done before any mycroft (neon) import
+
 def setup_holmes_config():
+    """
+    Runs at module init to ensure base holmes.conf exists to patch ovos-core. Note that this must run before any import
+    of Configuration class.
+    """
     HOLMES_CONFIG = join(xdg.BaseDirectory.save_config_path("HolmesV"),
                          "holmes.conf")
 
@@ -55,25 +62,23 @@ def setup_holmes_config():
             "neon_enclosure": "neon_core"
         }
     }
+
     cfg = {}
-    if exists(HOLMES_CONFIG):
-        try:
-            with open(HOLMES_CONFIG) as f:
-                cfg = json.load(f)
-        except:
-            pass
+    try:
+        with open(HOLMES_CONFIG) as f:
+            cfg = json.load(f)
+    except Exception as e:
+        LOG.error(e)
+
     cfg = merge_dict(cfg, _NEON_HOLMES_CONFIG)
     with open(HOLMES_CONFIG, "w") as f:
         json.dump(cfg, f, indent=4, ensure_ascii=True)
 
-# make holmesV Configuration.get() load neon.conf
-# TODO HolmesV does not yet support yaml configs, once it does
-#  Configuration.get() will be made to load the existing neon config files,
-#  for now it simply provides correct default values
-setup_holmes_config()
-
 
 def setup_ovos_config():
+    """
+    Configure OVOS config to read from neon.conf files and set this path as the root.
+    """
     # ensure ovos_utils can find neon_core
     set_root_path(NEON_ROOT_PATH)
     # make ovos_utils load the proper .conf files
@@ -81,6 +86,16 @@ def setup_ovos_config():
 
 
 setup_ovos_config()
+
+# make holmesV Configuration.get() load neon.conf
+# TODO HolmesV does not yet support yaml configs, once it does
+#  Configuration.get() will be made to load the existing neon config files,
+#  for now it simply provides correct default values
+setup_holmes_config()
+
+neon_config_path = join(xdg.BaseDirectory.save_config_path("neon"),
+                        "neon.conf")
+write_mycroft_compatible_config(neon_config_path)
 
 # patch version string to allow downstream to know where it is running
 import mycroft.version

--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -90,8 +90,8 @@ def setup_ovos_config():
 
 setup_ovos_config()
 
-# make holmesV Configuration.get() load neon.conf
-# TODO HolmesV does not yet support yaml configs, once it does
+# make ovos-core Configuration.get() load neon.conf
+# TODO ovos-core does not yet support yaml configs, once it does
 #  Configuration.get() will be made to load the existing neon config files,
 #  for now it simply provides correct default values
 setup_ovos_core_config()
@@ -99,6 +99,7 @@ setup_ovos_core_config()
 neon_config_path = join(xdg.BaseDirectory.save_config_path("neon"),
                         "neon.conf")
 write_mycroft_compatible_config(neon_config_path)
+LOG.info(f"{neon_config_path} will be overwritten with Neon YAML config contents.")
 
 # patch version string to allow downstream to know where it is running
 import mycroft.version

--- a/neon_core/run_neon.py
+++ b/neon_core/run_neon.py
@@ -123,8 +123,8 @@ def _stop_all_core_processes():
     procs = {p.pid: p.cmdline() for p in psutil.process_iter()}
     for pid, cmdline in procs.items():
         if cmdline and (any(pname in cmdline[-1] for pname in ("mycroft.messagebus.service", "neon_speech_client",
-                                                               "neon_audio_client",
-                                                               "neon_core.skills", "neon_core.gui"
+                                                               "neon_audio_client", "neon_core.messagebus.service",
+                                                               "neon_core.skills", "neon_core.gui",
                                                                "neon_core_server", "neon_enclosure_client",
                                                                "neon_core_client", "mycroft-gui-app",
                                                                "NGI.utilities.gui", "run_neon.py")
@@ -138,7 +138,7 @@ def _stop_all_core_processes():
                 psutil.Process(pid).terminate()
                 sleep(1)
                 if psutil.pid_exists(pid) and psutil.Process(pid).is_running():
-                    LOG.error(f"Process {pid} not terminated!!")
+                    LOG.info(f"Process {pid} not terminated!!")
                     psutil.Process(pid).kill()
             except Exception as e:
                 LOG.error(e)


### PR DESCRIPTION
Fixes typo in run_neon preventing gui, server, and messagebus services from being stopped
Add annotations to methods in neon_core.__init__ and exports Mycroft-compatible config from YML configs (closes #159)
Refactor Holmes to OVOS config