### PR TITLE
Cleanup Documentation and Imports

### DIFF
--- a/neon_core/configuration/__init__.py
+++ b/neon_core/configuration/__init__.py
@@ -1,3 +1,28 @@
+# # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# # All trademark and other rights reserved by their respective owners
+# # Copyright 2008-2021 Neongecko.com Inc.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from mycroft.configuration.config import Configuration, LocalConf
 
 def get_private_keys():

--- a/neon_core/dialog/__init__.py
+++ b/neon_core/dialog/__init__.py
@@ -22,10 +22,12 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from os.path import join
+from neon_utils import LOG
+
 from mycroft.dialog import MustacheDialogRenderer, load_dialogs
 from mycroft.util import resolve_resource_file
-from mycroft.util.log import LOG
 
 
 def get(phrase, lang=None, context=None):

--- a/neon_core/gui/resting_screen.py
+++ b/neon_core/gui/resting_screen.py
@@ -26,7 +26,7 @@
 import time
 
 from threading import Lock
-from neon_utils.log_utils import LOG
+from neon_utils import LOG
 from mycroft_bus_client import Message, MessageBusClient
 from neon_utils.skills.mycroft_skill import MycroftSkill
 

--- a/neon_core/messagebus/__init__.py
+++ b/neon_core/messagebus/__init__.py
@@ -22,13 +22,14 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import json
+from threading import Event
 from mycroft_bus_client import MessageBusClient, Message
+
 from mycroft.messagebus.service.event_handler import MessageBusEventHandler
 from mycroft.util import create_daemon
 from mycroft.messagebus.load_config import load_message_bus_config
 from mycroft.util.json_helper import merge_dict
-import json
-from threading import Event
 
 
 def get_messagebus(running=True):

--- a/neon_core/messagebus/service/__init__.py
+++ b/neon_core/messagebus/service/__init__.py
@@ -30,14 +30,15 @@ systems to integrate with the Mycroft system.
 """
 import asyncio
 import sys
+import tornado.options
+
 from os.path import expanduser, isfile
 from threading import Thread
+from tornado import web, ioloop
+from neon_utils import LOG
 
-import tornado.options
 from mycroft.messagebus.load_config import load_message_bus_config
 from mycroft.messagebus.service.event_handler import MessageBusEventHandler
-from mycroft.util.log import LOG
-from tornado import web, ioloop
 
 
 class NeonBusService(Thread):

--- a/neon_core/processing_modules/__init__.py
+++ b/neon_core/processing_modules/__init__.py
@@ -23,15 +23,16 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from threading import Thread, Event
-from os.path import join, basename
 import os
 import time
 import sys
 import gc
-from glob import glob
 import imp
-from mycroft.util.log import LOG
+
+from glob import glob
+from threading import Thread, Event
+from os.path import join, basename
+from neon_utils import LOG
 
 DEBUG = True
 

--- a/neon_core/skills/__main__.py
+++ b/neon_core/skills/__main__.py
@@ -1,3 +1,28 @@
+# # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# # All trademark and other rights reserved by their respective owners
+# # Copyright 2008-2021 Neongecko.com Inc.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from mycroft.lock import Lock
 from mycroft.util import reset_sigint_handler, wait_for_exit_signal
 from neon_core.skills.service import NeonSkillService

--- a/neon_core/skills/decorators.py
+++ b/neon_core/skills/decorators.py
@@ -23,14 +23,16 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Decorators for use with MycroftSkill methods"""
-from functools import wraps
-import threading
-from inspect import signature
 import time
-from mycroft.messagebus import Message
+import threading
+
+from functools import wraps
+from inspect import signature
+from mycroft_bus_client import Message
+from ovos_utils import create_killable_daemon
+
 from mycroft.skills.mycroft_skill.decorators import intent_handler, \
     intent_file_handler, resting_screen_handler, skill_api_method
-from ovos_utils import create_killable_daemon
 
 
 class AbortEvent(StopIteration):

--- a/neon_core/skills/display_service.py
+++ b/neon_core/skills/display_service.py
@@ -24,7 +24,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import time
-from mycroft.messagebus.message import Message
+from mycroft_bus_client import Message
 from neon_core.messagebus import get_messagebus
 from os.path import abspath
 

--- a/neon_core/skills/neon_skill.py
+++ b/neon_core/skills/neon_skill.py
@@ -1,3 +1,28 @@
+# # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# # All trademark and other rights reserved by their respective owners
+# # Copyright 2008-2021 Neongecko.com Inc.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import re
 from os import walk
 from os.path import join, exists

--- a/neon_core/skills/service.py
+++ b/neon_core/skills/service.py
@@ -24,22 +24,23 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import time
 
+from neon_utils.configuration_utils import get_neon_skills_config, \
+    get_neon_lang_config, get_neon_local_config
+from neon_utils.net_utils import check_online
+from neon_utils import LOG
+from neon_utils.metrics_utils import announce_connection
+
+from neon_core.skills.fallback_skill import FallbackSkill
+from neon_core.skills.intent_service import NeonIntentService
+from neon_core.skills.skill_manager import NeonSkillManager
+from neon_core.util.diagnostic_utils import report_metric
+
 from mycroft.skills.api import SkillApi
 from mycroft.skills.event_scheduler import EventScheduler
 from mycroft.skills.msm_wrapper import MsmException
 from mycroft.util import start_message_bus_client
 from mycroft.configuration.locale import set_default_lang, set_default_tz
-from mycroft.util.log import LOG
 from mycroft.util.process_utils import ProcessStatus, StatusCallbackMap
-from neon_core.skills.fallback_skill import FallbackSkill
-from neon_core.skills.intent_service import NeonIntentService
-from neon_core.skills.skill_manager import NeonSkillManager
-from neon_utils.configuration_utils import get_neon_skills_config, \
-    get_neon_lang_config, get_neon_local_config
-from neon_utils.net_utils import check_online
-
-from neon_core.util.diagnostic_utils import report_metric
-from neon_utils.metrics_utils import announce_connection
 
 
 def on_started():

--- a/neon_core/skills/skill_store.py
+++ b/neon_core/skills/skill_store.py
@@ -25,17 +25,15 @@
 
 from ovos_skills_manager.osm import OVOSSkillsManager
 from ovos_skills_manager.skill_entry import SkillEntry
-# from neon_core.configuration import Configuration
+from neon_utils import LOG
+from neon_utils.net_utils import check_online
+from neon_utils.authentication_utils import repo_is_neon
+from neon_utils.configuration_utils import get_neon_skills_config
+from datetime import datetime, timedelta
+
 from neon_core.messagebus import get_messagebus
 from neon_core.util.skill_utils import get_remote_entries
 from mycroft.skills.event_scheduler import EventSchedulerInterface
-from mycroft.util import connected
-from mycroft.util.log import LOG
-# from os.path import expanduser
-from datetime import datetime, timedelta
-
-from neon_utils.authentication_utils import repo_is_neon
-from neon_utils.configuration_utils import get_neon_skills_config
 
 
 class SkillsStore:
@@ -76,7 +74,7 @@ class SkillsStore:
         try:
             self.install_default_skills(update=True)
         except Exception as e:
-            if connected():
+            if check_online():
                 # if there is internet log the error
                 LOG.exception(e)
                 LOG.error("skills update failed")
@@ -88,7 +86,7 @@ class SkillsStore:
         try:
             self.osm.sync_appstores()
         except Exception as e:
-            if connected():
+            if check_online():
                 # if there is internet log the error
                 LOG.exception(e)
                 LOG.error("appstore sync failed")

--- a/neon_core/stt/__init__.py
+++ b/neon_core/stt/__init__.py
@@ -23,4 +23,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # backwards compatibility
+
 from neon_speech.stt import *
+from neon_utils import LOG
+LOG.warning(f"This reference is deprecated. Import from neon_speech.stt directly!")
+# TODO: Deprecate in neon_core 22.04

--- a/neon_core/tts/__init__.py
+++ b/neon_core/tts/__init__.py
@@ -24,3 +24,6 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from neon_audio.tts import TTS, PlaybackThread, TTSValidator, TTSFactory, load_tts_plugin
+from neon_utils import LOG
+LOG.warning(f"This reference is deprecated. Import from neon_audio.tts directly!")
+# TODO: Deprecate in neon_core 22.04

--- a/neon_core/util/skill_utils.py
+++ b/neon_core/util/skill_utils.py
@@ -27,7 +27,7 @@ from os.path import expanduser
 from ovos_skills_manager.osm import OVOSSkillsManager
 from ovos_skills_manager.session import SESSION as requests, set_github_token, clear_github_token
 from neon_utils.configuration_utils import get_neon_skills_config
-from neon_utils.log_utils import LOG
+from neon_utils import LOG
 
 
 def install_skills_from_list(skills_to_install: list, config: dict = None):


### PR DESCRIPTION
Add any missing license file headers
Consolidate all LOG imports to neon_utils
Refactor superseded `mycroft` imports
Mark stt and tts modules as deprecated