### PR TITLE
Add user profile data to messages in intent_service

### DIFF
--- a/neon_core/skills/intent_service.py
+++ b/neon_core/skills/intent_service.py
@@ -155,8 +155,8 @@ class NeonIntentService(IntentService):
             message.context["timing"]["handle_utterance"] = time.time()
 
             # Ensure user profile data is present
-            if "profiles" not in message.context:
-                message.context["profiles"] = [self.default_user.content]
+            if "user_profiles" not in message.context:
+                message.context["user_profiles"] = [self.default_user.content]
                 message.context["username"] = self.default_user.content["username"]
 
             # Make sure there is a `transcribed` timestamp (should have been added in speech module)


### PR DESCRIPTION
Defines "profiles" and "username" as required context params in Messages passed to intent handlers. `profiles` is defined as a list of user profiles (dict), `username` is a unique ID associated with the user making the request.

Multiple profiles are provided to support multi-user conversations on Klat; in most cases it will likely be a list of length 1.

Partially inspired by #24
Partially addresses #138 
Relates to https://github.com/NeonGeckoCom/chat_api_mq_proxy/issues/2