### PR TITLE
Restructure dependencies

### DIFF
--- a/neon_core/messagebus/__init__.py
+++ b/neon_core/messagebus/__init__.py
@@ -23,7 +23,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from neon_messagebus.util.message_utils import get_messagebus
+from neon_utils.messagebus_utils import get_messagebus
 from neon_utils import LOG
 LOG.warning("This reference is deprecated; import from neon_messagebus directly")
 # TODO: Deprecate in neon_core 22.04

--- a/neon_core/skills/skill_store.py
+++ b/neon_core/skills/skill_store.py
@@ -31,7 +31,7 @@ from neon_utils.authentication_utils import repo_is_neon
 from neon_utils.configuration_utils import get_neon_skills_config
 from datetime import datetime, timedelta
 
-from neon_messagebus.util.message_utils import get_messagebus
+from neon_utils.messagebus_utils import get_messagebus
 from neon_core.util.skill_utils import get_remote_entries
 from mycroft.skills.event_scheduler import EventSchedulerInterface
 

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,0 +1,9 @@
+ovos-core[all]~=0.0.1
+
+# neon core modules
+neon_enclosure~=0.1,>=0.1.2
+neon_messagebus
+neon_speech~=0.3
+neon_audio~=0.4
+neon_gui
+# TODO: Version spec GUI

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,27 +1,17 @@
 # mycroft
-# TODO: Reduce ovos-core installed deps here
-ovos-core[all]==0.0.1
+ovos-core[skills]==0.0.1
 mock_msm
-
-# neon core modules
-neon_messagebus
-neon_speech~=0.3
-neon_audio~=0.4
-neon_enclosure~=0.1,>=0.1.2
-neon_gui
-# TODO: Version spec GUI
 
 # utils
 neon-utils~=0.12,>=0.14.3a7
 # TODO: Update to stable version
 ovos_utils~=0.0.12
 ovos-skills-manager~=0.0.8
+# TODO: Patching OPM
+ovos-plugin-manager==0.0.2
 
 # plugins
 neon-lang-plugin-libretranslate~=0.1,>=0.1.2
-
-# TODO: Patching OPM
-ovos-plugin-manager==0.0.2
 
 # text parser modules
 RAKEkeywords~=0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,8 +7,10 @@ neon-utils~=0.12,>=0.14.3a7
 # TODO: Update to stable version
 ovos_utils~=0.0.12
 ovos-skills-manager~=0.0.8
+
 # TODO: Patching OPM
 ovos-plugin-manager==0.0.2
+SpeechRecognition~=3.8
 
 # plugins
 neon-lang-plugin-libretranslate~=0.1,>=0.1.2

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=get_requirements('requirements.txt'),
     extras_require={
+        "core_modules": get_requirements("core_modules.txt"),
         "client": get_requirements("client.txt"),
         "server": get_requirements("server.txt"),
         "dev": get_requirements("dev.txt"),

--- a/setup.sh
+++ b/setup.sh
@@ -265,7 +265,7 @@ doInstall(){
     fi
 
   # Build optional dependency string for pip installation
-    options=()
+    options=("core_modules")
     if [ "${localDeps}" == "true" ]; then
       if [ "${arm}" == "true" ]; then
         echo "Local Dependencies not supported on ARM; remote STT/TTS will be used."

--- a/test/setup_dev_local.sh
+++ b/test/setup_dev_local.sh
@@ -42,7 +42,7 @@ export ttsModule="neon_tts_mimic"
 
 localDeps="true"
 installGui="false"
-options=()
+options=("core_modules")
 options+=("test")
 if [ "${localDeps}" == "true" ]; then
   options+=("local")

--- a/test/setup_remote.sh
+++ b/test/setup_remote.sh
@@ -43,7 +43,7 @@ export ttsModule="amazon"
 
 localDeps="false"
 installGui="false"
-options=()
+options=("core_modules")
 options+=("test")
 if [ "${localDeps}" == "true" ]; then
   options+=("local")


### PR DESCRIPTION
Move core modules out of base requirements.txt to minimize skills-only installations
Update `get_messagebus` imports to use neon_utils instead of neon_messagebus to reduce dependencies