### PR TITLE
ovos_utils config update compat

### DIFF
--- a/neon_core/config.py
+++ b/neon_core/config.py
@@ -28,7 +28,6 @@ import os
 
 from os.path import join, dirname
 from ovos_utils.json_helper import merge_dict
-from ovos_utils.system import set_root_path
 from ovos_utils.xdg_utils import xdg_config_home
 
 from neon_utils.logger import LOG

--- a/neon_core/configuration/__init__.py
+++ b/neon_core/configuration/__init__.py
@@ -28,3 +28,23 @@ from mycroft.configuration.config import Configuration
 
 def get_private_keys():
     return Configuration.get(remote=False).get("keys", {})
+
+
+def get_json_config() -> dict:
+    """
+    Wraps `get_ovos_config` so stack trace resolves the correct core
+    :returns: dict config for neon
+    """
+    from ovos_config_assistant.config_helpers import get_ovos_config
+    return get_ovos_config()
+
+
+def get_default_json_config_paths() -> list:
+    """
+    Wraps `get_ovos_default_config_paths`
+      so stack trace resolves the correct core
+    :returns: list of configuration file paths that will be used
+    """
+    from ovos_config_assistant.config_helpers import \
+        get_ovos_default_config_paths
+    return get_ovos_default_config_paths()

--- a/neon_core/configuration/__init__.py
+++ b/neon_core/configuration/__init__.py
@@ -28,23 +28,3 @@ from mycroft.configuration.config import Configuration
 
 def get_private_keys():
     return Configuration.get(remote=False).get("keys", {})
-
-
-def get_json_config() -> dict:
-    """
-    Wraps `get_ovos_config` so stack trace resolves the correct core
-    :returns: dict config for neon
-    """
-    from ovos_config_assistant.config_helpers import get_ovos_config
-    return get_ovos_config()
-
-
-def get_default_json_config_paths() -> list:
-    """
-    Wraps `get_ovos_default_config_paths`
-      so stack trace resolves the correct core
-    :returns: list of configuration file paths that will be used
-    """
-    from ovos_config_assistant.config_helpers import \
-        get_ovos_default_config_paths
-    return get_ovos_default_config_paths()

--- a/neon_core/util/runtime_utils.py
+++ b/neon_core/util/runtime_utils.py
@@ -1,0 +1,34 @@
+# # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# # All trademark and other rights reserved by their respective owners
+# # Copyright 2008-2021 Neongecko.com Inc.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+def use_neon_core(func):
+    """
+    Wrapper to ensure call originates from neon_core for stack checks
+    """
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+

--- a/neon_core/util/runtime_utils.py
+++ b/neon_core/util/runtime_utils.py
@@ -26,7 +26,9 @@
 
 def use_neon_core(func):
     """
-    Wrapper to ensure call originates from neon_core for stack checks
+    Wrapper to ensure call originates from neon_core for stack checks.
+    This is used for ovos-utils config platform detection which uses the stack
+    to determine which module config to return.
     """
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -8,7 +8,7 @@ ovos-ww-plugin-pocketsphinx~=0.1.2
 # neon core modules
 neon_enclosure~=0.1,>=0.1.2
 neon_messagebus
-neon_speech~=0.3,>=0.3.3a4
+neon_speech~=0.3,>=0.3.3a7
 neon_audio~=0.4,>=0.4.3a4
 neon_gui
 # TODO: Version spec GUI

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,8 +2,8 @@
 ovos-core[skills_lgpl]~=0.0.2a10
 
 # utils
-neon-utils~=0.12,>=0.15.1a7
-ovos_utils~=0.0.18
+neon-utils~=0.12,>=0.15.1a10
+ovos_utils~=0.0.19,>=0.0.19a3
 ovos-skills-manager~=0.0.10a20
 ovos-plugin-manager~=0.0.4,>=0.0.7a0
 # TODO: Update to stable versions

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -35,37 +35,31 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 class ConfigurationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
+        from ovos_config_assistant.config_helpers import \
+            get_ovos_config, get_ovos_default_config_paths
         ovos_config = os.path.expanduser("~/.config/OpenVoiceOS/ovos.conf")
         if os.path.isfile(ovos_config):
             os.remove(ovos_config)
-        # assert get_default_json_config_paths() == []
+        assert get_ovos_default_config_paths() == []
 
         import neon_core
-        from neon_core.configuration import get_json_config, \
-            get_default_json_config_paths
-
-        assert isinstance(neon_core.CORE_VERSION_STR, str)
-        assert len(get_default_json_config_paths()) == 1
-        LOG.info(get_default_json_config_paths())
-        ovos_config = get_json_config()
-        LOG.info(pformat(ovos_config))
-        assert ovos_config['config_filename'] == 'neon.conf'
-
         from neon_core.util.runtime_utils import use_neon_core
 
-        @staticmethod
-        @use_neon_core
-        def wrapped_function_call(func, *args, **kwargs):
-            return func(*args, **kwargs)
-
-        cls.wrapped_function_call = wrapped_function_call
+        assert isinstance(neon_core.CORE_VERSION_STR, str)
+        assert len(use_neon_core(get_ovos_default_config_paths)()) == 1
+        LOG.info(use_neon_core(get_ovos_default_config_paths)())
+        ovos_config = use_neon_core(get_ovos_config)()
+        LOG.info(pformat(ovos_config))
+        assert ovos_config['config_filename'] == 'neon.conf'
 
     def test_neon_core_config_init(self):
         from neon_utils.configuration_utils import \
             get_mycroft_compatible_config
         from neon_core.configuration import Configuration
+        from neon_core.util.runtime_utils import use_neon_core
+
         neon_compat_config = Configuration.get()
-        neon_config = self.wrapped_function_call(get_mycroft_compatible_config)
+        neon_config = use_neon_core(get_mycroft_compatible_config)()
         for key, val in neon_config.items():
             if isinstance(val, dict):
                 for k, v in val.items():
@@ -79,8 +73,10 @@ class ConfigurationTests(unittest.TestCase):
         from neon_utils.configuration_utils import \
             get_mycroft_compatible_config
         from mycroft.configuration import Configuration as MycroftConfig
+        from neon_core.util.runtime_utils import use_neon_core
+
         mycroft_config = MycroftConfig.get()
-        neon_config = self.wrapped_function_call(get_mycroft_compatible_config)
+        neon_config = use_neon_core(get_mycroft_compatible_config)()
         for key, val in neon_config.items():
             if isinstance(val, dict):
                 for k, v in val.items():
@@ -98,9 +94,9 @@ class ConfigurationTests(unittest.TestCase):
 
         from neon_core.util.runtime_utils import use_neon_core
 
-        self.assertEqual(neon_ipc_dir, self.wrapped_function_call(ovos_ipc_dir))
+        self.assertEqual(neon_ipc_dir, use_neon_core(ovos_ipc_dir)())
         self.assertEqual(neon_ipc_dir,
-                         self.wrapped_function_call(mycroft_ipc_dir))
+                         use_neon_core(mycroft_ipc_dir)())
 
 
 if __name__ == '__main__':

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -26,7 +26,7 @@
 import os
 import sys
 import unittest
-# from pprint import pformat
+from pprint import pformat
 
 from neon_utils.logger import LOG
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -46,9 +46,9 @@ class ConfigurationTests(unittest.TestCase):
         assert isinstance(neon_core.CORE_VERSION_STR, str)
         assert len(config_helpers.get_ovos_default_config_paths()) == 1
         LOG.info(config_helpers.get_ovos_default_config_paths())
-        # ovos_config = config_helpers.get_ovos_config()
-        # LOG.info(pformat(ovos_config))
-        # assert ovos_config['config_filename'] == 'neon.conf'
+        ovos_config = config_helpers.get_ovos_config()
+        LOG.info(pformat(ovos_config))
+        assert ovos_config['config_filename'] == 'neon.conf'
 
     def test_neon_core_config_init(self):
         from neon_utils.configuration_utils import \

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -35,18 +35,19 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 class ConfigurationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        from ovos_config_assistant import config_helpers
+        from neon_core.configuration import get_json_config, \
+            get_default_json_config_paths
 
         ovos_config = os.path.expanduser("~/.config/OpenVoiceOS/ovos.conf")
         if os.path.isfile(ovos_config):
             os.remove(ovos_config)
-        assert config_helpers.get_ovos_default_config_paths() == []
+        assert get_default_json_config_paths() == []
 
         import neon_core
         assert isinstance(neon_core.CORE_VERSION_STR, str)
-        assert len(config_helpers.get_ovos_default_config_paths()) == 1
-        LOG.info(config_helpers.get_ovos_default_config_paths())
-        ovos_config = config_helpers.get_ovos_config()
+        assert len(get_default_json_config_paths()) == 1
+        LOG.info(get_default_json_config_paths())
+        ovos_config = get_json_config()
         LOG.info(pformat(ovos_config))
         assert ovos_config['config_filename'] == 'neon.conf'
 

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -26,7 +26,7 @@
 import os
 import sys
 import unittest
-from pprint import pformat
+# from pprint import pformat
 
 from neon_utils.logger import LOG
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -46,9 +46,9 @@ class ConfigurationTests(unittest.TestCase):
         assert isinstance(neon_core.CORE_VERSION_STR, str)
         assert len(config_helpers.get_ovos_default_config_paths()) == 1
         LOG.info(config_helpers.get_ovos_default_config_paths())
-        ovos_config = config_helpers.get_ovos_config()
-        LOG.info(pformat(ovos_config))
-        assert ovos_config['config_filename'] == 'neon.conf'
+        # ovos_config = config_helpers.get_ovos_config()
+        # LOG.info(pformat(ovos_config))
+        # assert ovos_config['config_filename'] == 'neon.conf'
 
     def test_neon_core_config_init(self):
         from neon_utils.configuration_utils import \


### PR DESCRIPTION
Update tests and add helper methods for ovos-utils configuration resolver update compat.
`use_neon_core` decorator should be used for any calls originating outside of core modules that expect a configuration object that matches the one used by core modules