### PR TITLE
Add manual workflow to build/push an image with updated skills

### DIFF
--- a/.github/workflows/update_skills_image.yml
+++ b/.github/workflows/update_skills_image.yml
@@ -7,7 +7,7 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/neon_skills
 
 jobs:
-  build_and_publish_docker:
+  update_default_skills_image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -17,11 +17,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
-      - name: Get Version
-        id: version
-        run: |
-          VERSION=$(sed "s/a/-a./" <<< $(python setup.py --version))
-          echo ::set-output name=version::${VERSION}
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -36,7 +31,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-default_skills
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
             type=ref,event=branch
       - name: Build and push default_skills Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/update_skills_image.yml
+++ b/.github/workflows/update_skills_image.yml
@@ -9,7 +9,6 @@ env:
 jobs:
   build_and_publish_docker:
     runs-on: ubuntu-latest
-    needs: increment_version
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/update_skills_image.yml
+++ b/.github/workflows/update_skills_image.yml
@@ -1,0 +1,49 @@
+name: Update Skills Image
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/neon_skills
+
+jobs:
+  build_and_publish_docker:
+    runs-on: ubuntu-latest
+    needs: increment_version
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+      - name: Get Version
+        id: version
+        run: |
+          VERSION=$(sed "s/a/-a./" <<< $(python setup.py --version))
+          echo ::set-output name=version::${VERSION}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for default_skills Docker
+        id: default_skills_meta
+        uses: docker/metadata-action@v2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-default_skills
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
+            type=ref,event=branch
+      - name: Build and push default_skills Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.default_skills_meta.outputs.tags }}
+          labels: ${{ steps.default_skills_meta.outputs.labels }}
+          target: default_skills


### PR DESCRIPTION
With this, the "Update Skill Image" workflow will rebuild the `neon_skills-default_skills` image for the specified branch. This is useful for updating skills without any changes to the skills base image. Note that version tagged images are not affected so pinned installations are static as expected