### PR TITLE
Add bus API method to get supported languages with unit test

### DIFF
--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -1,6 +1,10 @@
 # Plugin Configuration
-text_parsers:
-  blacklist: []
+utterance_transformers:
+  neon_utterance_translator_plugin:
+    active: True
+  neon_utterance_normalizer_plugin:
+    active: True
+
 audio_parsers:
   blacklist:
   - gender

--- a/neon_core/skills/intent_service.py
+++ b/neon_core/skills/intent_service.py
@@ -44,7 +44,6 @@ from neon_utils.configuration_utils import get_neon_user_config
 from lingua_franca.parse import get_full_lang_code
 from ovos_config.locale import set_default_lang
 from mycroft.skills.intent_service import IntentService
-from ovos_plugin_manager.templates.language import LanguageTranslator
 
 try:
     from neon_utterance_translator_plugin import UtteranceTranslator

--- a/neon_core/skills/intent_service.py
+++ b/neon_core/skills/intent_service.py
@@ -65,7 +65,7 @@ class NeonIntentService(IntentService):
     def __init__(self, bus: MessageBusClient):
         super().__init__(bus)
         self.converse = NeonConverseService(bus)
-        self.config = Configuration.get().get('context', {})
+        self.config = Configuration()
         self.language_config = get_lang_config()
 
         # Initialize default user to inject into incoming messages
@@ -76,7 +76,7 @@ class NeonIntentService(IntentService):
 
         # self._setup_converse_handlers()
 
-        self.transformers = UtteranceTransformersService(self.bus)
+        self.transformers = UtteranceTransformersService(self.bus, self.config)
 
         self.transcript_service = None
         if Transcribe:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,7 +11,7 @@ ovos-plugin-manager~=0.0.16,>=0.0.19a1
 psutil~=5.6
 
 # default plugins
-neon-lang-plugin-libretranslate~=0.1,>=0.1.3a0
+neon-lang-plugin-libretranslate~=0.1,>=0.1.2
 neon-utterance-translator-plugin~=0.1
 neon-utterance-normalizer-plugin~=0.0.0,>=0.0.1a0
 # text parser modules

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,12 +6,12 @@ neon-transformers~=0.1
 ovos_utils~=0.0,>=0.0.23
 ovos-config~=0.0,>=0.0.4
 ovos-skills-manager~=0.0,>=0.0.11
-ovos-plugin-manager~=0.0.16
+ovos-plugin-manager~=0.0.16,>=0.0.19a1
 
 psutil~=5.6
 
 # default plugins
-neon-lang-plugin-libretranslate~=0.1,>=0.1.2
+neon-lang-plugin-libretranslate~=0.1,>=0.1.3a0
 neon-utterance-translator-plugin~=0.1
 neon-utterance-normalizer-plugin~=0.0.0,>=0.0.1a0
 # text parser modules

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
 pytest
 pytest-cov
 mock~=4.0
-neon-lang-plugin-libretranslate>=0.1.2

--- a/test/test_skills_module.py
+++ b/test/test_skills_module.py
@@ -168,15 +168,22 @@ class TestSkillService(unittest.TestCase):
 
 class TestIntentService(unittest.TestCase):
     bus = FakeBus()
+    test_config_dir = join(dirname(__file__), "test_config")
 
     @classmethod
     def setUpClass(cls) -> None:
+        os.environ["XDG_CONFIG_HOME"] = cls.test_config_dir
+        from neon_utils.configuration_utils import init_config_dir
+        init_config_dir()
+
         from neon_core import NeonIntentService
         cls.intent_service = NeonIntentService(cls.bus)
 
     @classmethod
     def tearDownClass(cls) -> None:
         cls.intent_service.shutdown()
+        os.environ.pop("XDG_CONFIG_HOME")
+        shutil.rmtree(cls.test_config_dir)
 
     def test_save_utterance_transcription(self):
         self.intent_service.transcript_service = Mock()


### PR DESCRIPTION
Add `neon.get_languages_skills` handler
Needs language plugin update in OPM https://github.com/OpenVoiceOS/OVOS-plugin-manager/pull/73