### PR TITLE
Refactor skill installation to detect and handle pip skill specs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,5 +52,4 @@ CMD ["/root/run.sh"]
 
 FROM base as default_skills
 RUN pip install .[skills_required,skills_essential,skills_default,skills_extended]
-# TODO: Default skill installation is a temporary step until all skills are pip installable
-RUN neon-install-default-skills
+# Default skills from configuration are installed at container creation

--- a/docker/config/neon.yaml
+++ b/docker/config/neon.yaml
@@ -11,6 +11,7 @@ ready_settings:
   - gui
 skills:
   default_skills:
+    # Jokes skill included because it cannot be pip installed to the image
     - https://github.com/JarbasSkills/skill-icanhazdadjokes/tree/dev
 MQ:
   server: mq.2021.us

--- a/docker/config/neon.yaml
+++ b/docker/config/neon.yaml
@@ -9,6 +9,9 @@ ready_settings:
   - speech
   - audio
   - gui
+skills:
+  default_skills:
+    - https://github.com/JarbasSkills/skill-icanhazdadjokes/tree/dev
 MQ:
   server: mq.2021.us
   port: 25672

--- a/docker_overlay/root/run.sh
+++ b/docker_overlay/root/run.sh
@@ -27,6 +27,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Plugin installation must occur in a separate thread, before module load, for the entry point to be loaded.
+# Python package installation must occur in a separate thread, before module load, for the entry point to be loaded.
+neon install-skills-default
 neon install-skill-requirements /skills
 neon run-skills

--- a/docker_overlay/root/run.sh
+++ b/docker_overlay/root/run.sh
@@ -28,6 +28,6 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Python package installation must occur in a separate thread, before module load, for the entry point to be loaded.
-neon install-skills-default
+neon install-default-skills
 neon install-skill-requirements /skills
 neon run-skills

--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -83,6 +83,7 @@ listener:
   continuous_listen: false
   VAD:
     silence_method: vad_and_ratio
+    # vad_only, radio_only, current_only, vad_and_ratio, vad_and_current, all
     speech_seconds: 0.1
     silence_seconds: 0.5
     before_seconds: 0.5

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -43,6 +43,13 @@ TEST_SKILLS_NO_AUTH = [
     "https://github.com/NeonGeckoCom/caffeinewiz.neon/tree/dev",
     "https://github.com/NeonGeckoCom/launcher.neon/tree/dev"
 ]
+
+TEST_SKILLS_WITH_PIP = [
+    "https://github.com/NeonGeckoCom/skill-date_time/tree/dev",
+    "git+https://github.com/NeonGeckoCom/malls-parser-skill",
+    "neon-skill-support_helper"
+]
+
 TEST_SKILLS_WITH_AUTH = [
     "https://github.com/NeonGeckoCom/i-like-brands.neon/tree/dev",
     "https://github.com/NeonGeckoCom/i-like-coupons.neon/tree/dev"
@@ -105,6 +112,17 @@ class SkillUtilsTests(unittest.TestCase):
             len(get_remote_entries(SKILL_CONFIG["default_skills"])),
             f"{skill_dirs}\n\n"
             f"{get_remote_entries(SKILL_CONFIG['default_skills'])}")
+
+    def test_install_skills_with_pip(self):
+        from neon_core.util.skill_utils import install_skills_from_list
+        install_skills_from_list(TEST_SKILLS_WITH_PIP, SKILL_CONFIG)
+        skill_dirs = [d for d in os.listdir(SKILL_DIR)
+                      if os.path.isdir(os.path.join(SKILL_DIR, d))]
+        self.assertEqual(len(skill_dirs), 1)
+        self.assertIn("skill-date_time.neongeckocom", skill_dirs)
+        from ovos_plugin_manager.skills import find_skill_plugins
+        skills = find_skill_plugins().keys()
+        self.assertIn("skill-support_helper.neongeckocom", skills)
 
     def test_get_neon_skills_data(self):
         from neon_core.util.skill_utils import get_neon_skills_data

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -120,9 +120,10 @@ class SkillUtilsTests(unittest.TestCase):
                       if os.path.isdir(os.path.join(SKILL_DIR, d))]
         self.assertEqual(len(skill_dirs), 1)
         self.assertIn("skill-date_time.neongeckocom", skill_dirs)
-        from ovos_plugin_manager.skills import find_skill_plugins
-        skills = find_skill_plugins().keys()
-        self.assertIn("skill-support_helper.neongeckocom", skills)
+
+        import pip
+        returned = pip.main(['show', 'neon-skill-support-helper'])
+        self.assertEqual(returned, 0)
 
     def test_get_neon_skills_data(self):
         from neon_core.util.skill_utils import get_neon_skills_data

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -121,8 +121,7 @@ class SkillUtilsTests(unittest.TestCase):
         self.assertEqual(len(skill_dirs), 1)
         self.assertIn("skill-date_time.neongeckocom", skill_dirs)
 
-        import pip
-        returned = pip.main(['show', 'neon-skill-support-helper'])
+        returned = os.system("pip show neon-skill-support-helper")
         self.assertEqual(returned, 0)
 
     def test_get_neon_skills_data(self):


### PR DESCRIPTION
With this, `Configuration()['skills']['default_skills']` is a list that may include URLs for "legacy" skills, git URL specs, or pip package specs. Docker implementations will install all of these skills on container creation; updates/installation by `SkillManager` will NOT load pip installed skills until the service is restarted.