### PR TITLE
RPi Python 3.10 Compatible Dependencies

### DIFF
--- a/requirements/local_speech_processing.txt
+++ b/requirements/local_speech_processing.txt
@@ -1,9 +1,11 @@
 neon-stt-plugin-deepspeech-stream-local~=2.0
+neon-stt-plugin-nemo
 neon-tts-plugin-coqui~=0.7,>=0.7.1
 
 # TODO: Local language plugin
 
-# Fallback TTS
+# Fallback
+ovos-stt-plugin-vosk
 ovos-tts-plugin-mimic
 
 # Backwards-compat. for tests

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -30,7 +30,7 @@ ovos-phal-plugin-balena-wifi~=1.0.0
 ovos-phal-plugin-gui-network-client~=0.0.2
 ovos-phal-plugin-network-manager~=1.0.0
 ovos-phal-plugin-wifi-setup~=1.0.0
-ovos-phal-plugin-dashboard~=0.0.1
+ovos-phal-plugin-dashboard>=0.0.2a3
 ovos-phal-plugin-alsa~=0.0.2
 ovos-phal-plugin-system~=0.0.2
 ovos-phal-plugin-ipgeo @ git+https://github.com/OpenVoiceOS/ovos-PHAL-plugin-ipgeo

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -9,7 +9,7 @@ neon-cli-client~=0.2
 
 # Default plugins
 ovos-ww-plugin-vosk~=0.0,>=0.0.4
-neon-stt-plugin-google-cloud-streaming~=1.0
+neon-stt-plugin-google-cloud-streaming~=1.0,>=1.0.1a0
 neon-tts-plugin-coqui-remote
 
 # Fallback plugins

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -34,7 +34,7 @@ ovos-phal-plugin-alsa~=0.0.2
 ovos-phal-plugin-system~=0.0.2
 ovos-phal-plugin-ipgeo @ git+https://github.com/OpenVoiceOS/ovos-PHAL-plugin-ipgeo
 ovos-phal-plugin-gpsd @ git+https://github.com/OpenVoiceOS/ovos-PHAL-plugin-gpsd
-ovos-phal-plugin-homeassistant @ git+https://github.com/neondaniel/ovos-PHAL-plugin-homeassistant@FEAT_WebsocketAPI
+# ovos-phal-plugin-homeassistant @ git+https://github.com/neondaniel/ovos-PHAL-plugin-homeassistant@FEAT_WebsocketAPI
 
 # Pi-specific skills
 ovos-skill-homescreen @ git+https://github.com/OpenVoiceOS/skill-ovos-homescreen

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -1,6 +1,6 @@
 # ARM-specific releases
-deepspeech @ https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-cp37-cp37m-linux_aarch64.whl
-vosk @ https://github.com/alphacep/vosk-api/releases/download/v0.3.30/vosk-0.3.30-py3-none-linux_aarch64.whl
+# deepspeech @ https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-cp37-cp37m-linux_aarch64.whl
+# vosk @ https://github.com/alphacep/vosk-api/releases/download/v0.3.30/vosk-0.3.30-py3-none-linux_aarch64.whl
 
 # SystemD integration
 sdnotify~=0.3
@@ -11,8 +11,11 @@ neon-cli-client~=0.2
 # Default plugins
 ovos-ww-plugin-vosk~=0.0,>=0.0.4
 neon-stt-plugin-google-cloud-streaming~=1.0
-neon-tts-plugin-larynx_server~=0.2
 neon-tts-plugin-coqui-remote
+
+# Fallback plugins
+neon-tts-plugin-coqui~=0.7,>=0.7.1
+ovos-stt-plugin-vosk
 
 # PHAL Plugins
 neon-phal-plugin-fan~=0.0.3

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -1,6 +1,5 @@
 # ARM-specific releases
 # deepspeech @ https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-cp37-cp37m-linux_aarch64.whl
-# vosk @ https://github.com/alphacep/vosk-api/releases/download/v0.3.30/vosk-0.3.30-py3-none-linux_aarch64.whl
 
 # SystemD integration
 sdnotify~=0.3
@@ -15,7 +14,7 @@ neon-tts-plugin-coqui-remote
 
 # Fallback plugins
 neon-tts-plugin-coqui~=0.7,>=0.7.1
-ovos-stt-plugin-vosk
+ovos-stt-plugin-vosk~=0.1
 
 # PHAL Plugins
 neon-phal-plugin-fan~=0.0.3

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -35,6 +35,8 @@ ovos-phal-plugin-alsa~=0.0.2
 ovos-phal-plugin-system~=0.0.2
 ovos-phal-plugin-ipgeo @ git+https://github.com/OpenVoiceOS/ovos-PHAL-plugin-ipgeo
 ovos-phal-plugin-gpsd @ git+https://github.com/OpenVoiceOS/ovos-PHAL-plugin-gpsd
+ovos-phal-plugin-homeassistant @ git+https://github.com/neondaniel/ovos-PHAL-plugin-homeassistant@FEAT_WebsocketAPI
+
 # Pi-specific skills
 ovos-skill-homescreen @ git+https://github.com/OpenVoiceOS/skill-ovos-homescreen
 ovos-skill-setup @ git+https://github.com/OpenVoiceOS/skill-ovos-setup

--- a/test/pi_setup.sh
+++ b/test/pi_setup.sh
@@ -46,9 +46,6 @@ python3.7 -m venv "/core/venv" || exit 11
 . /core/venv/bin/activate
 
 pip install --upgrade pip wheel
-pip install ".[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi,local]" || exit 11
+pip install ".[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi]" || exit 11
 
 cp -rf /core/test/pi_image_overlay/* /
-# TODO: Remove patched STT config
-wget -O /root/.local/share/neon/deepspeech-0.9.3-models.scorer https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-models.scorer
-wget -O /root/.local/share/neon/deepspeech-0.9.3-models.tflite https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-models.tflite

--- a/test/pi_setup.sh
+++ b/test/pi_setup.sh
@@ -38,11 +38,11 @@ apt install -y curl
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
-apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev python3.7-dev python3.7-venv mimic espeak-ng g++ libjpeg-dev make || exit 1
+apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev python3.10-dev python3.10-venv mimic espeak-ng g++ libjpeg-dev make || exit 1
 
 # Configure venv for deepspeech compat.
 cd /core || exit 10
-python3.7 -m venv "/core/venv" || exit 11
+python3.10 -m venv "/core/venv" || exit 11
 . /core/venv/bin/activate
 
 pip install --upgrade pip wheel


### PR DESCRIPTION
Update dependencies for Python3.10 compatibility on RPi
Update dependency versions to include RPi offline fallback support