### PR TITLE
ovos-workshop refactor

### DIFF
--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -26,34 +26,41 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import importlib
+import neon_utils.skills
+import mycroft.skills.core
+
 from neon_utils.skills.mycroft_skill import PatchedMycroftSkill
 from neon_core.skills.neon_skill import NeonSkill
 from neon_core.skills.fallback_skill import NeonFallbackSkill
 from neon_core.skills.decorators import intent_handler, intent_file_handler, \
     resting_screen_handler, conversational_intent
 
-try:
-    import ovos_workshop.skills
-    ovos_workshop.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
-    import importlib
-    importlib.reload(ovos_workshop.skills.ovos)
-    importlib.reload(ovos_workshop.skills.fallback)
-    importlib.reload(ovos_workshop.skills)
-except (ImportError, AttributeError):
-    import importlib
-    import mycroft.skills.core
-    mycroft.MycroftSkill = PatchedMycroftSkill
-    mycroft.skills.MycroftSkill = PatchedMycroftSkill
-    mycroft.skills.core.MycroftSkill = PatchedMycroftSkill
-    mycroft.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
+# Patch the base skill
+import ovos_workshop.skills
+ovos_workshop.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
 
-    importlib.reload(mycroft.skills.fallback_skill)
-    importlib.reload(mycroft.skills.common_play_skill)
-    importlib.reload(mycroft.skills.common_query_skill)
-    importlib.reload(mycroft.skills.common_iot_skill)
+# Reload ovos_workshop modules with Patched class
+importlib.reload(ovos_workshop.skills.ovos)
+importlib.reload(ovos_workshop.skills.fallback)
+importlib.reload(ovos_workshop.skills)
 
-    mycroft.skills.core.FallbackSkill = mycroft.skills.fallback_skill.FallbackSkill
-    mycroft.skills.FallbackSkill = mycroft.skills.fallback_skill.FallbackSkill
+# Reload neon_utils modules with Patched class
+importlib.reload(neon_utils.skills.neon_fallback_skill)
+importlib.reload(neon_utils.skills)
+
+# Reload mycroft modules with Patched class
+importlib.reload(mycroft.skills.mycroft_skill.mycroft_skill)
+importlib.reload(mycroft.skills.mycroft_skill)
+importlib.reload(mycroft.skills.fallback_skill)
+importlib.reload(mycroft.skills.common_play_skill)
+importlib.reload(mycroft.skills.common_query_skill)
+importlib.reload(mycroft.skills.common_iot_skill)
+importlib.reload(mycroft.skills)
+
+# Manually patch re-defined classes in `mycroft.skills.core`
+mycroft.skills.core.MycroftSkill = PatchedMycroftSkill
+mycroft.skills.core.FallbackSkill = mycroft.skills.fallback_skill.FallbackSkill
 
 
 __all__ = ['NeonSkill',

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,5 +1,5 @@
 # neon core modules
-ovos-core[audio]@git+https://github.com/openvoiceos/ovos-core@refactor/skill_class_from_workshop
+ovos-core[audio]>=0.0.6a16
 # TODO: Above patching version for neon_audio
 neon_messagebus~=0.3
 neon_gui~=1.1,>=1.1.1

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -6,3 +6,6 @@ neon_gui~=1.1,>=1.1.1
 neon_enclosure~=1.2
 neon_speech~=3.0,>=3.0.2a4
 neon_audio~=1.2,>=1.2.2a6
+
+# TODO: Patching OCP Compat
+ovos_plugin_common_play~=0.0, >=0.0.3a14

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,5 +1,5 @@
 # neon core modules
-ovos-core[audio]~=0.0.5,>=0.0.6a10
+ovos-core[audio]@git+https://github.com/openvoiceos/ovos-core@refactor/skill_class_from_workshop
 # TODO: Above patching version for neon_audio
 neon_messagebus~=0.3
 neon_gui~=1.1,>=1.1.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ ovos_utils~=0.0,>=0.0.27a4
 ovos-config~=0.0.5
 ovos-skills-manager~=0.0.11,>=0.0.12a3
 ovos-plugin-manager~=0.0.20
-ovos-workshop@git+https://github.com/openvoiceos/ovos-workshop@refactor/patches
+ovos-workshop>=0.0.10a3
 psutil~=5.6
 
 # default plugins

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 # mycroft
-ovos-core[skills_lgpl]~=0.0.5,>=0.0.6a3,<=0.0.6a15
+ovos-core[skills_lgpl]@git+https://github.com/openvoiceos/ovos-core@refactor/skill_class_from_workshop
 # utils
 neon-utils[network,configuration]~=1.2
 neon-transformers~=0.2
@@ -7,11 +7,7 @@ ovos_utils~=0.0,>=0.0.27a4
 ovos-config~=0.0.5
 ovos-skills-manager~=0.0.11,>=0.0.12a3
 ovos-plugin-manager~=0.0.20
-ovos-workshop@git+https://github.com/openvoiceos/ovos-workshop@refactor/patches
 psutil~=5.6
-
-# TODO: Patching compat.
-ovos-workshop<0.0.10a3
 
 # default plugins
 neon-lang-plugin-libretranslate~=0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 # mycroft
-ovos-core[skills_lgpl]@git+https://github.com/openvoiceos/ovos-core@refactor/skill_class_from_workshop
+ovos-core[skills_lgpl]>=0.0.6a16
 # utils
 neon-utils[network,configuration]@git+https://github.com/neongeckocom/neon-skill-utils@REF_SkillsFromOvosWorkshop
 neon-transformers~=0.2
@@ -7,7 +7,7 @@ ovos_utils~=0.0,>=0.0.27a4
 ovos-config~=0.0.5
 ovos-skills-manager~=0.0.11,>=0.0.12a3
 ovos-plugin-manager~=0.0.20
-ovos-workshop>=0.0.10a4
+ovos-workshop>=0.0.10a5
 psutil~=5.6
 
 # default plugins

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,6 +7,7 @@ ovos_utils~=0.0,>=0.0.27a4
 ovos-config~=0.0.5
 ovos-skills-manager~=0.0.11,>=0.0.12a3
 ovos-plugin-manager~=0.0.20
+ovos-workshop@git+https://github.com/openvoiceos/ovos-workshop@refactor/patches
 psutil~=5.6
 
 # TODO: Patching compat.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 # mycroft
 ovos-core[skills_lgpl]@git+https://github.com/openvoiceos/ovos-core@refactor/skill_class_from_workshop
 # utils
-neon-utils[network,configuration]~=1.2
+neon-utils[network,configuration]@git+https://github.com/neongeckocom/neon-skill-utils@REF_SkillsFromOvosWorkshop
 neon-transformers~=0.2
 ovos_utils~=0.0,>=0.0.27a4
 ovos-config~=0.0.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,13 +1,12 @@
 # mycroft
 ovos-core[skills_lgpl]>=0.0.6a16
 # utils
-neon-utils[network,configuration]@git+https://github.com/neongeckocom/neon-skill-utils@REF_SkillsFromOvosWorkshop
+neon-utils[network,configuration]~=1.2,>=1.2.1a0
 neon-transformers~=0.2
-ovos_utils~=0.0,>=0.0.27a4
+ovos_utils~=0.0.27
 ovos-config~=0.0.5
 ovos-skills-manager~=0.0.11,>=0.0.12a3
 ovos-plugin-manager~=0.0.20
-ovos-workshop>=0.0.10a5
 psutil~=5.6
 
 # default plugins

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,6 +7,7 @@ ovos_utils~=0.0,>=0.0.27a4
 ovos-config~=0.0.5
 ovos-skills-manager~=0.0.11,>=0.0.12a3
 ovos-plugin-manager~=0.0.20
+ovos-workshop@git+https://github.com/openvoiceos/ovos-workshop@refactor/patches
 psutil~=5.6
 
 # default plugins

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ ovos_utils~=0.0,>=0.0.27a4
 ovos-config~=0.0.5
 ovos-skills-manager~=0.0.11,>=0.0.12a3
 ovos-plugin-manager~=0.0.20
-ovos-workshop>=0.0.10a3
+ovos-workshop>=0.0.10a4
 psutil~=5.6
 
 # default plugins

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -194,14 +194,39 @@ class SkillUtilsTests(unittest.TestCase):
         from mycroft.skills.common_play_skill import CommonPlaySkill
         from mycroft.skills.common_query_skill import CommonQuerySkill
         from mycroft.skills.common_iot_skill import CommonIoTSkill
+
         self.assertEqual(MycroftSkill, PatchedMycroftSkill)
         self.assertEqual(MycroftSkill2, PatchedMycroftSkill)
         self.assertEqual(MycroftSkill3, PatchedMycroftSkill)
         self.assertEqual(FallbackSkill, FallbackSkill2)
+
         self.assertTrue(issubclass(FallbackSkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonPlaySkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonIoTSkill, PatchedMycroftSkill))
+
+        from ovos_workshop.skills.mycroft_skill import MycroftSkill as Patched
+        from ovos_workshop.skills import MycroftSkill as Patched2
+        from ovos_workshop.skills.ovos import MycroftSkill as Patched3
+        self.assertEqual(Patched, PatchedMycroftSkill)
+        self.assertEqual(Patched2, PatchedMycroftSkill)
+        self.assertEqual(Patched3, PatchedMycroftSkill)
+
+        from ovos_workshop.skills.ovos import OVOSSkill
+        from ovos_workshop.skills import OVOSSkill as OVOSSkill2
+        self.assertTrue(issubclass(OVOSSkill, PatchedMycroftSkill))
+        self.assertEqual(OVOSSkill, OVOSSkill2)
+
+        from neon_utils.skills import NeonFallbackSkill, NeonSkill
+        self.assertTrue(issubclass(NeonFallbackSkill, PatchedMycroftSkill))
+        self.assertTrue(issubclass(NeonSkill, PatchedMycroftSkill))
+        self.assertTrue(issubclass(NeonFallbackSkill, OVOSSkill))
+
+        from neon_utils.skills.neon_fallback_skill import NeonFallbackSkill as \
+            NeonFallbackSkill2
+        from neon_utils.skills.neon_skill import NeonSkill as NeonSkill2
+        self.assertEqual(NeonFallbackSkill, NeonFallbackSkill2)
+        self.assertEqual(NeonSkill, NeonSkill2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update dependencies to include the ovos-workshop refactor that moves skill base classes out of the `mycroft` module and into `ovos-workshop` for better import availability and improved compat.