### PR TITLE
Troubleshooting ovos-workshop overrides

### DIFF
--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -40,11 +40,11 @@ init_config_dir()
 CORE_VERSION_STR = get_core_version()
 setup_resolve_resource_file()
 
-from neon_core.skills import NeonSkill, NeonFallbackSkill
+# from neon_core.skills import NeonSkill, NeonFallbackSkill
 from neon_core.skills.intent_service import NeonIntentService
 
 __all__ = ['NEON_ROOT_PATH',
            'NeonIntentService',
-           'NeonSkill',
-           'NeonFallbackSkill',
+           # 'NeonSkill',
+           # 'NeonFallbackSkill',
            'CORE_VERSION_STR']

--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -32,14 +32,6 @@ from neon_core.skills.fallback_skill import NeonFallbackSkill
 from neon_core.skills.decorators import intent_handler, intent_file_handler, \
     resting_screen_handler, conversational_intent
 
-from mycroft.skills.intent_services.adapt_service import AdaptIntent
-
-import mycroft.skills.core
-mycroft.MycroftSkill = PatchedMycroftSkill
-mycroft.skills.MycroftSkill = PatchedMycroftSkill
-mycroft.skills.core.MycroftSkill = PatchedMycroftSkill
-mycroft.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
-
 try:
     import ovos_workshop.skills
     ovos_workshop.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
@@ -49,15 +41,19 @@ try:
     importlib.reload(ovos_workshop.skills)
 except (ImportError, AttributeError):
     import importlib
+    import mycroft.skills.core
+    mycroft.MycroftSkill = PatchedMycroftSkill
+    mycroft.skills.MycroftSkill = PatchedMycroftSkill
+    mycroft.skills.core.MycroftSkill = PatchedMycroftSkill
+    mycroft.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
 
-importlib.reload(mycroft.skills.fallback_skill)
-importlib.reload(mycroft.skills.common_play_skill)
-importlib.reload(mycroft.skills.common_query_skill)
-importlib.reload(mycroft.skills.common_iot_skill)
+    importlib.reload(mycroft.skills.fallback_skill)
+    importlib.reload(mycroft.skills.common_play_skill)
+    importlib.reload(mycroft.skills.common_query_skill)
+    importlib.reload(mycroft.skills.common_iot_skill)
 
-mycroft.skills.core.FallbackSkill = mycroft.skills.fallback_skill.FallbackSkill
-
-mycroft.skills.intent_service.AdaptIntent = AdaptIntent
+    mycroft.skills.core.FallbackSkill = mycroft.skills.fallback_skill.FallbackSkill
+    mycroft.skills.FallbackSkill = mycroft.skills.fallback_skill.FallbackSkill
 
 
 __all__ = ['NeonSkill',

--- a/neon_core/skills/fallback_skill.py
+++ b/neon_core/skills/fallback_skill.py
@@ -26,9 +26,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from mycroft.skills import FallbackSkill
-from neon_core.skills.neon_skill import NeonSkill
-
-
-class NeonFallbackSkill(FallbackSkill, NeonSkill):
-    """"""
+from neon_utils.skills.neon_fallback_skill import NeonFallbackSkill
+from ovos_utils.log import LOG
+LOG.warning(f"This module is deprecated. "
+            f"import from `neon_utils.skills.neon_fallback_skill` directly")

--- a/neon_core/skills/service.py
+++ b/neon_core/skills/service.py
@@ -26,11 +26,10 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
 
 from tempfile import gettempdir
 from os import listdir
-from os.path import isdir, dirname, join
+from os.path import join
 from typing import Optional
 from threading import Thread
 
@@ -38,21 +37,22 @@ from mycroft_bus_client import Message, MessageBusClient
 from ovos_config.locale import set_default_lang, set_default_tz
 from ovos_config.config import Configuration
 from ovos_utils.log import LOG
-from ovos_utils.process_utils import ProcessState
 from ovos_utils.skills.locations import get_plugin_skills, get_skill_directories
+from ovos_utils.process_utils import StatusCallbackMap
 from neon_utils.metrics_utils import announce_connection
 from neon_utils.signal_utils import init_signal_handlers, init_signal_bus
 from neon_utils.messagebus_utils import get_messagebus
 
-from neon_core.skills.fallback_skill import FallbackSkill
 from neon_core.skills.intent_service import NeonIntentService
 from neon_core.skills.skill_manager import NeonSkillManager
 from neon_core.util.diagnostic_utils import report_metric
 from neon_core.util.qml_file_server import start_qml_http_server
 
+from mycroft.skills.fallback_skill import FallbackSkill
+# TODO: Update to import from ovos-workshop
+
 from mycroft.skills.api import SkillApi
 from mycroft.skills.event_scheduler import EventScheduler
-from mycroft.util.process_utils import ProcessStatus, StatusCallbackMap
 
 
 def on_started():

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 # mycroft
-ovos-core[skills_lgpl]~=0.0.5,>=0.0.6a3
+ovos-core[skills_lgpl]~=0.0.5,>=0.0.6a3,<=0.0.6a15
 # utils
-neon-utils[network,configuration]~=1.1,>=1.1.3a15
+neon-utils[network,configuration]~=1.2
 neon-transformers~=0.2
 ovos_utils~=0.0,>=0.0.27a4
 ovos-config~=0.0.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,6 +9,9 @@ ovos-skills-manager~=0.0.11,>=0.0.12a3
 ovos-plugin-manager~=0.0.20
 psutil~=5.6
 
+# TODO: Patching compat.
+ovos-workshop<0.0.10a3
+
 # default plugins
 neon-lang-plugin-libretranslate~=0.2
 neon-utterance-translator-plugin~=0.1


### PR DESCRIPTION
Prevent extra skill object patching with ovos-workshop refactor
Remove deprecated imports
Mark FallbackSkill module as deprecated (should import from neon_utils)