### PR TITLE
Update to default to Padacioso instead of Padatious

### DIFF
--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -167,7 +167,7 @@ padatious:
   intent_cache: ~/.local/share/mycroft/intent_cache
   train_delay: 4
   single_thread: false
-  padaos_only: false
+  regex_only: true
 # GUI Service
 gui:
   extension: generic

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 # mycroft
-ovos-core[skills_lgpl]~=0.0.7
+ovos-core[skills]~=0.0.7
 # utils
 neon-utils[network,configuration]~=1.3,>=1.3.1a1
 ovos-bus-client~=0.0.2,>=0.0.3a18


### PR DESCRIPTION
# Description
Updates default dependencies and config to use Padacioso intent parser instead of Padatious for more predictable intent matching.

# Issues
closes #417 

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->