### PR TITLE
Fix disable changelog automation

### DIFF
--- a/.github/workflows/propose_release.yml
+++ b/.github/workflows/propose_release.yml
@@ -6,7 +6,7 @@ jobs:
     uses: neongeckocom/.github/.github/workflows/propose_dated_release.yml@master
     with:
       branch: dev
-      update_changelog: true
+      update_changelog: false
   pull_changes:
     uses: neongeckocom/.github/.github/workflows/pull_master.yml@master
     with:

--- a/.github/workflows/propose_release.yml
+++ b/.github/workflows/propose_release.yml
@@ -7,6 +7,7 @@ jobs:
     with:
       branch: dev
       update_changelog: false
+      # Changelog automation fails with this large repo
   pull_changes:
     uses: neongeckocom/.github/.github/workflows/pull_master.yml@master
     with:

--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -19,7 +19,7 @@ jobs:
       setup_py: "setup.py"
       publish_pypi: false
       publish_prerelease: true
-      update_changelog: true
+      update_changelog: false
   build_and_publish_docker:
     needs: publish_alpha_release
     uses: neongeckocom/.github/.github/workflows/publish_docker.yml@master

--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -20,6 +20,7 @@ jobs:
       publish_pypi: false
       publish_prerelease: true
       update_changelog: false
+      # Changelog automation fails with this large repo
   build_and_publish_docker:
     needs: publish_alpha_release
     uses: neongeckocom/.github/.github/workflows/publish_docker.yml@master


### PR DESCRIPTION
# Description
Disables changelog automation that fails for repositories with many releases

# Issues
Fixes bug introduced in #432 

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->