### PR TITLE
Update ovos-workshop version with compat patches

### DIFF
--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -40,7 +40,7 @@ ovos_workshop.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
 workshop_modules = ("ovos_workshop.skills.ovos",
                     "ovos_workshop.skills.fallback",
                     "ovos_workshop.skills.common_query_skill",
-                    "ovos_workshop.skills.common_play"
+                    "ovos_workshop.skills.common_play",
                     "ovos_workshop.skills")
 neon_utils_modules = ("neon_utils.skills.neon_fallback_skill",
                       "neon_utils.skills")

--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -39,6 +39,8 @@ ovos_workshop.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
 
 workshop_modules = ("ovos_workshop.skills.ovos",
                     "ovos_workshop.skills.fallback",
+                    "ovos_workshop.skills.common_query_skill",
+                    "ovos_workshop.skills.common_play"
                     "ovos_workshop.skills")
 neon_utils_modules = ("neon_utils.skills.neon_fallback_skill",
                       "neon_utils.skills")

--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -83,6 +83,8 @@ import mycroft.skills.core
 mycroft.skills.core.MycroftSkill = PatchedMycroftSkill
 mycroft.skills.core.FallbackSkill = mycroft.skills.fallback_skill.FallbackSkill
 
+# TODO: Remove below patch with ovos-core 0.0.8 refactor
+import neon_core.skills.patched_plugin_loader
 
 __all__ = ['intent_handler',
            'intent_file_handler',

--- a/neon_core/skills/patched_plugin_loader.py
+++ b/neon_core/skills/patched_plugin_loader.py
@@ -1,0 +1,15 @@
+# TODO: Remove below patches with ovos-core 0.0.8
+import mycroft.skills.skill_loader
+from mycroft.skills.skill_loader import PluginSkillLoader as _Plugin
+
+
+class PluginSkillLoader(_Plugin):
+    def __int__(self, *args, **kwargs):
+        _Plugin.__init__(self, *args, **kwargs)
+
+    def load(self, skill_class=None):
+        skill_class = skill_class or self._skill_class
+        _Plugin.load(self, skill_class)
+
+
+mycroft.skills.skill_loader.PluginSkillLoader = PluginSkillLoader

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,8 @@ ovos-workshop~=0.0.11,>=0.0.12a26
 neon-utils[network,configuration]~=1.4,>=1.5.0a2
 ovos-bus-client~=0.0.3
 neon-transformers~=0.2
-ovos_utils~=0.0.32
+ovos_utils[extras]~=0.0.32,>=0.0.33a7
+# TODO extras patching dependency resolution
 ovos-config~=0.0.8
 ovos-skills-manager~=0.0.12
 ovos-plugin-manager~=0.0.21

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,6 @@
 # mycroft
 ovos-core[skills,skills-lgpl]~=0.0.7
+ovos-workshop~=0.0.11,>=0.0.12a26
 # padacioso==0.1.3a2
 
 # utils

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -24,3 +24,4 @@ requests < 2.30.0
 
 # TODO: Patching alpha dependency resolution
 neon-utils[audio]~=1.4,>=1.5.0a2
+neon-utils[audio,network]~=1.4,>=1.5.0a2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -25,3 +25,4 @@ requests < 2.30.0
 # TODO: Patching alpha dependency resolution
 neon-utils[audio]~=1.4,>=1.5.0a2
 neon-utils[audio,network]~=1.4,>=1.5.0a2
+neon-utils[network]~=1.4,>=1.5.0a2

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -233,6 +233,17 @@ class SkillUtilsTests(unittest.TestCase):
         self.assertEqual(NeonFallbackSkill, NeonFallbackSkill2)
         self.assertEqual(NeonSkill, NeonSkill2)
 
+        from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
+        self.assertTrue(issubclass(OVOSCommonPlaybackSkill,
+                                   PatchedMycroftSkill))
+
+        try:
+            from ovos_workshop.skills.common_query_skill import CommonQuerySkill
+            self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
+        except ImportError:
+            # TODO: Remove exception handling here with ovos-workshop dependency update
+            # Older ovos-workshop did not include this class
+            pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -237,13 +237,9 @@ class SkillUtilsTests(unittest.TestCase):
         self.assertTrue(issubclass(OVOSCommonPlaybackSkill,
                                    PatchedMycroftSkill))
 
-        try:
-            from ovos_workshop.skills.common_query_skill import CommonQuerySkill
-            self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
-        except ImportError:
-            # TODO: Remove exception handling here with ovos-workshop dependency update
-            # Older ovos-workshop did not include this class
-            pass
+        from ovos_workshop.skills.common_query_skill import CommonQuerySkill
+        self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description
Updates skill patching for compat. with latest ovos-workshop with updated unit tests
Adds patched PluginSkillLoader to implement fixes in ovos-workshop prior to ovos-core 0.0.8 update

# Issues
Closes #424

# Other Notes
The patched PluginSkillLoader class will be removed when NeonCore updates ovos-core to 0.0.8