### PR TITLE
Update core-updater PHAL plugin to resolve GH release order bug

### DIFF
--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -21,7 +21,7 @@ ovos-stt-plugin-vosk~=0.1,>=0.1.4
 
 # PHAL Plugins
 neon-phal-plugin-reset~=0.1,>=0.1.1a2
-neon-phal-plugin-core-updater~=1.0
+neon-phal-plugin-core-updater~=1.0,>=1.0.1a0
 neon-phal-plugin-fan~=0.0.3
 neon-phal-plugin-switches~=0.0.3
 neon-phal-plugin-linear_led~=0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@ ovos-workshop~=0.0.11,>=0.0.12a26
 # padacioso==0.1.3a2
 
 # utils
-neon-utils[network,configuration]~=1.4,>=1.5.0a3
+neon-utils[network,configuration]~=1.4,>=1.5.0a5
 ovos-bus-client~=0.0.3
 neon-transformers~=0.2
 ovos_utils[extras]~=0.0.32,>=0.0.33a7


### PR DESCRIPTION
# Description
Update core-updater plugin to resolve GH pre-release ordering quirk

# Issues
Resolves dependency error from #441 

# Other Notes
https://github.com/NeonGeckoCom/neon-phal-plugin-core-updater/pull/20