### PR TITLE
Update configuration init handling

### DIFF
--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -28,7 +28,6 @@
 
 import sys
 
-from neon_utils.configuration_utils import init_config_dir
 from neon_core.config import get_core_version, \
     setup_resolve_resource_file
 from os.path import dirname
@@ -36,7 +35,6 @@ from os.path import dirname
 
 NEON_ROOT_PATH = dirname(__file__)
 sys.path.append(NEON_ROOT_PATH)
-init_config_dir()
 
 CORE_VERSION_STR = get_core_version()
 setup_resolve_resource_file()

--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -26,24 +26,23 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import sys
+# import sys
 
-from neon_core.config import get_core_version, \
-    setup_resolve_resource_file
-from os.path import dirname
+from neon_core.config import setup_resolve_resource_file
+# from os.path import dirname
 
 
-NEON_ROOT_PATH = dirname(__file__)
-sys.path.append(NEON_ROOT_PATH)
+# NEON_ROOT_PATH = dirname(__file__)
+# sys.path.append(NEON_ROOT_PATH)
 
-CORE_VERSION_STR = get_core_version()
+# CORE_VERSION_STR = get_core_version()
 setup_resolve_resource_file()
 
 # from neon_core.skills import NeonSkill, NeonFallbackSkill
-from neon_core.skills.intent_service import NeonIntentService
+# from neon_core.skills.intent_service import NeonIntentService
 
-__all__ = ['NEON_ROOT_PATH',
-           'NeonIntentService',
-           # 'NeonSkill',
-           # 'NeonFallbackSkill',
-           'CORE_VERSION_STR']
+# __all__ = ['NEON_ROOT_PATH',
+#            'NeonIntentService',
+#            # 'NeonSkill',
+#            # 'NeonFallbackSkill',
+#            'CORE_VERSION_STR']

--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -26,23 +26,17 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# import sys
+import sys
 
-from neon_core.config import setup_resolve_resource_file
-# from os.path import dirname
+from neon_core.config import setup_resolve_resource_file, get_core_version
+from os.path import dirname
 
 
-# NEON_ROOT_PATH = dirname(__file__)
-# sys.path.append(NEON_ROOT_PATH)
+NEON_ROOT_PATH = dirname(__file__)
+sys.path.append(NEON_ROOT_PATH)
 
-# CORE_VERSION_STR = get_core_version()
+CORE_VERSION_STR = get_core_version()
 setup_resolve_resource_file()
 
-# from neon_core.skills import NeonSkill, NeonFallbackSkill
-# from neon_core.skills.intent_service import NeonIntentService
-
-# __all__ = ['NEON_ROOT_PATH',
-#            'NeonIntentService',
-#            # 'NeonSkill',
-#            # 'NeonFallbackSkill',
-#            'CORE_VERSION_STR']
+__all__ = ['NEON_ROOT_PATH',
+           'CORE_VERSION_STR']

--- a/neon_core/cli.py
+++ b/neon_core/cli.py
@@ -99,6 +99,9 @@ def install_skill_requirements(skill_dir):
 @click.option("--install-skills", "-i", default=None,
               help="Path to local skills for which to install dependencies")
 def run_skills(install_skills):
+    from neon_utils.configuration_utils import init_config_dir
+    init_config_dir()
+
     from neon_core.util.skill_utils import install_local_skills
     from neon_core.skills.__main__ import main
     if install_skills:

--- a/neon_core/config.py
+++ b/neon_core/config.py
@@ -32,8 +32,8 @@ def get_core_version() -> str:
     Get the core version string.
     NOTE: `init_config` should be called before this method
     """
-    from neon_core.configuration import Configuration
-    Configuration.load_all_configs({"disable_remote_config": True})
+    # from neon_core.configuration import Configuration
+    # Configuration.load_all_configs({"disable_remote_config": True})
 
     # patch version string to allow downstream to know where it is running
     import mycroft.version

--- a/neon_core/run_neon.py
+++ b/neon_core/run_neon.py
@@ -35,10 +35,14 @@ from signal import SIGTERM
 from threading import Event
 from subprocess import Popen, STDOUT
 from mycroft_bus_client import MessageBusClient, Message
+from typing.io import IO
+
+from neon_utils.configuration_utils import init_config_dir
+init_config_dir()
+
 from ovos_utils.gui import is_gui_running
 from neon_utils.log_utils import remove_old_logs, archive_logs, LOG, \
     get_log_file_for_module
-from typing.io import IO
 
 LOG_FILES = {}
 PROCESSES = {}
@@ -158,7 +162,7 @@ def start_neon():
     bus.connected_event.wait()
     _start_process(["neon-speech", "run"]) or STOP_MODULES.set()
     _start_process(["neon-audio", "run"]) or STOP_MODULES.set()
-    _start_process(["python3", "-m", "neon_core.skills"]) or STOP_MODULES.set()
+    _start_process(["neon", "run-skills"]) or STOP_MODULES.set()
     _start_process(["neon-enclosure", "run"]) or STOP_MODULES.set()
     # TODO: neon-enclosure run-admin
     _start_process("neon_transcripts_controller")
@@ -168,7 +172,7 @@ def start_neon():
     if not is_gui_running():
         _start_process("mycroft-gui-app")
     # _start_process("neon_core_client")
-    _start_process(["neon_gui_service"])
+    _start_process(["neon-gui", "run"])
 
     try:
         STOP_MODULES.wait()

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,8 +1,8 @@
 # neon core modules
-neon_messagebus~=0.3,>=0.3.2a5
-neon_gui~=1.1,>=1.1.3a3
+neon_messagebus~=1.0
+neon_gui~=1.1,>=1.1.3a4
 neon_enclosure~=1.4,>=1.4.3a2
-neon_speech~=3.3,>=3.3.2a6
+neon_speech~=3.3,>=3.3.2a7
 neon_audio~=1.3,>=1.3.3a3
 
 ovos-vad-plugin-webrtcvad~=0.0.1

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,9 +1,6 @@
 # neon core modules
 neon_messagebus~=1.0
 neon_gui~=1.1,>=1.1.3a4
-neon_enclosure~=1.4,>=1.4.3a2
+neon_enclosure~=1.5
 neon_speech~=3.3,>=3.3.2a7
 neon_audio~=1.3,>=1.3.3a3
-
-ovos-vad-plugin-webrtcvad~=0.0.1
-# Ensure configured default VAD plugin is installed

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ ovos-workshop~=0.0.11,>=0.0.12a26
 
 # utils
 # neon-utils[network]~=1.4,>=1.5.0a9
-git+https://github.com/neongeckocom/neon-utils@FEAT_InitConfigDirInSetup#egg=neon-utils[network]
+neon-utils[network] @ git+https://github.com/neongeckocom/neon-utils@FEAT_InitConfigDirInSetup#egg=neon-utils
 ovos-bus-client~=0.0.3,>=0.0.4a12
 neon-transformers~=0.2
 ovos_utils[extras]~=0.0.32,>=0.0.33a9

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,8 @@ ovos-workshop~=0.0.11,>=0.0.12a26
 # padacioso==0.1.3a2
 
 # utils
-neon-utils[network]~=1.4,>=1.5.0a9
+# neon-utils[network]~=1.4,>=1.5.0a9
+git+https://github.com/neongeckocom/neon-utils@FEAT_InitConfigDirInSetup#egg=neon-utils[network]
 ovos-bus-client~=0.0.3,>=0.0.4a12
 neon-transformers~=0.2
 ovos_utils[extras]~=0.0.32,>=0.0.33a9

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,8 +4,7 @@ ovos-workshop~=0.0.11,>=0.0.12a26
 # padacioso==0.1.3a2
 
 # utils
-# neon-utils[network]~=1.4,>=1.5.0a9
-neon-utils[network] @ git+https://github.com/neongeckocom/neon-utils@FEAT_InitConfigDirInSetup#egg=neon-utils
+neon-utils[network]~=1.4,>=1.5.0a11
 ovos-bus-client~=0.0.3,>=0.0.4a12
 neon-transformers~=0.2
 ovos_utils[extras]~=0.0.32,>=0.0.33a9

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -49,12 +49,11 @@ class ConfigurationTests(unittest.TestCase):
         os.environ["XDG_CONFIG_HOME"] = cls.CONFIG_PATH
         use_neon_core(init_config_dir)()
 
-        import neon_core
-        assert isinstance(neon_core.CORE_VERSION_STR, str)
+        # import neon_core
+        # assert isinstance(neon_core.CORE_VERSION_STR, str)
         assert os.path.isfile(os.path.join(cls.CONFIG_PATH,
                                            "OpenVoiceOS", "ovos.conf"))
 
-        from neon_core.util.runtime_utils import use_neon_core
         from ovos_config.meta import get_ovos_config
         from neon_core.configuration import Configuration
         ovos_config = use_neon_core(get_ovos_config)()

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -38,16 +38,16 @@ from ovos_utils.log import LOG
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from neon_utils.configuration_utils import init_config_dir
-init_config_dir()
-
 
 class ConfigurationTests(unittest.TestCase):
     CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config")
 
     @classmethod
     def setUpClass(cls) -> None:
+        from neon_core.util.runtime_utils import use_neon_core
+        from neon_utils.configuration_utils import init_config_dir
         os.environ["XDG_CONFIG_HOME"] = cls.CONFIG_PATH
+        use_neon_core(init_config_dir)()
 
         import neon_core
         assert isinstance(neon_core.CORE_VERSION_STR, str)

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -28,15 +28,12 @@
 
 import os
 import shutil
-import sys
 import unittest
 import yaml
 
 from copy import deepcopy
 from pprint import pformat
 from ovos_utils.log import LOG
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 
 class ConfigurationTests(unittest.TestCase):
@@ -47,6 +44,8 @@ class ConfigurationTests(unittest.TestCase):
         from neon_core.util.runtime_utils import use_neon_core
         from neon_utils.configuration_utils import init_config_dir
         os.environ["XDG_CONFIG_HOME"] = cls.CONFIG_PATH
+        os.environ["OVOS_CONFIG_BASE_FOLDER"] = "neon"
+        os.environ["OVOS_CONFIG_FILENAME"] = "neon.yaml"
         use_neon_core(init_config_dir)()
 
         # import neon_core
@@ -67,6 +66,8 @@ class ConfigurationTests(unittest.TestCase):
         if os.path.exists(cls.CONFIG_PATH):
             shutil.rmtree(cls.CONFIG_PATH)
         os.environ.pop("XDG_CONFIG_HOME")
+        os.environ.pop("OVOS_CONFIG_BASE_FOLDER")
+        os.environ.pop("OVOS_CONFIG_FILENAME")
 
     def test_neon_core_config_init(self):
         from neon_core.configuration import Configuration

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -38,6 +38,9 @@ from ovos_utils.log import LOG
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
+from neon_utils.configuration_utils import init_config_dir
+init_config_dir()
+
 
 class ConfigurationTests(unittest.TestCase):
     CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config")

--- a/test/test_skills_module.py
+++ b/test/test_skills_module.py
@@ -176,7 +176,7 @@ class TestIntentService(unittest.TestCase):
         from neon_utils.configuration_utils import init_config_dir
         init_config_dir()
 
-        from neon_core import NeonIntentService
+        from neon_core.skills.intent_service import NeonIntentService
         cls.intent_service = NeonIntentService(cls.bus)
 
     @classmethod

--- a/test/test_skills_module.py
+++ b/test/test_skills_module.py
@@ -68,11 +68,12 @@ class TestSkillService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
+        from neon_core.util.runtime_utils import use_neon_core
+        from neon_utils.configuration_utils import init_config_dir
         os.environ["XDG_CONFIG_HOME"] = cls.config_dir
-        if os.path.exists(cls.config_dir):
-            shutil.rmtree(cls.config_dir)
-        from neon_core import CORE_VERSION_STR
-        assert isinstance(CORE_VERSION_STR, str)
+        os.environ["OVOS_CONFIG_BASE_FOLDER"] = "neon"
+        os.environ["OVOS_CONFIG_FILENAME"] = "neon.yaml"
+        use_neon_core(init_config_dir)()
         assert os.path.isdir(cls.config_dir)
 
     @classmethod
@@ -172,9 +173,12 @@ class TestIntentService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        os.environ["XDG_CONFIG_HOME"] = cls.test_config_dir
+        from neon_core.util.runtime_utils import use_neon_core
         from neon_utils.configuration_utils import init_config_dir
-        init_config_dir()
+        os.environ["XDG_CONFIG_HOME"] = cls.test_config_dir
+        os.environ["OVOS_CONFIG_BASE_FOLDER"] = "neon"
+        os.environ["OVOS_CONFIG_FILENAME"] = "neon.yaml"
+        use_neon_core(init_config_dir)()
 
         from neon_core.skills.intent_service import NeonIntentService
         cls.intent_service = NeonIntentService(cls.bus)
@@ -183,6 +187,8 @@ class TestIntentService(unittest.TestCase):
     def tearDownClass(cls) -> None:
         cls.intent_service.shutdown()
         os.environ.pop("XDG_CONFIG_HOME")
+        os.environ.pop("OVOS_CONFIG_BASE_FOLDER")
+        os.environ.pop("OVOS_CONFIG_FILENAME")
         shutil.rmtree(cls.test_config_dir)
 
     def test_save_utterance_transcription(self):
@@ -327,13 +333,18 @@ class TestSkillManager(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
+        from neon_core.util.runtime_utils import use_neon_core
+        from neon_utils.configuration_utils import init_config_dir
         os.environ["XDG_CONFIG_HOME"] = cls.config_dir
-        from neon_core import CORE_VERSION_STR
-        assert isinstance(CORE_VERSION_STR, str)
+        os.environ["OVOS_CONFIG_BASE_FOLDER"] = "neon"
+        os.environ["OVOS_CONFIG_FILENAME"] = "neon.yaml"
+        use_neon_core(init_config_dir)()
 
     @classmethod
     def tearDownClass(cls) -> None:
         os.environ.pop("XDG_CONFIG_HOME")
+        os.environ.pop("OVOS_CONFIG_BASE_FOLDER")
+        os.environ.pop("OVOS_CONFIG_FILENAME")
         if os.path.isdir(cls.config_dir):
             shutil.rmtree(cls.config_dir)
 


### PR DESCRIPTION
# Description
Move `init_config_dir` into CLI entrypoint and out of `__init__`
Update core dependencies to remove extra calls to `init_config_dir`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->