### PR TITLE
Update dependencies

### DIFF
--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -2,5 +2,5 @@
 neon_messagebus~=1.0
 neon_gui~=1.1,>=1.1.3a4
 neon_enclosure~=1.5
-neon_speech~=3.3,>=3.3.2a8
+neon_speech~=3.3,>=3.3.2a9
 neon_audio~=1.3,>=1.3.3a3

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -20,8 +20,8 @@ neon-tts-plugin-coqui~=0.7,>=0.7.1
 ovos-stt-plugin-vosk~=0.1,>=0.1.4
 
 # PHAL Plugins
-neon-phal-plugin-reset~=0.1,>=0.1.1a3
-neon-phal-plugin-core-updater~=1.0,>=1.0.1a3
+neon-phal-plugin-reset~=0.1,>=0.1.1a4
+neon-phal-plugin-core-updater~=1.0,>=1.0.1a5
 neon-phal-plugin-fan~=0.0.3
 neon-phal-plugin-switches~=0.0.3
 neon-phal-plugin-linear_led~=0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,5 +22,3 @@ neon-utterance-normalizer-plugin~=0.0.2
 
 # TODO: Patching test failures https://github.com/NeonGeckoCom/NeonCore/actions/runs/4888865255/jobs/8727164992?pr=422
 requests < 2.30.0
-# TODO: Patching https://github.com/python-attrs/cattrs/issues/369
-cattrs!=23.1.0


### PR DESCRIPTION
# Description
Update neon_speech to include hotword reloading with unit test
Update PHAL dependencies to clean up logging and improve default config handling
Remove `cattrs` version patch fixed upstream

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->