### PR TITLE
Update to stable packages and new default Pi VAD

### DIFF
--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -95,7 +95,7 @@ listener:
     initial_energy_threshold: 1000.0
     module: ovos-vad-plugin-webrtcvad
     ovos-vad-plugin-silero:
-      threshold: 0.2
+      threshold: 0.15
     ovos-vad-plugin-webrtcvad:
       vad_mode: 2
   mute_during_output: true

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -9,11 +9,12 @@ neon-cli-client~=0.2
 neon-mana-utils~=0.0.4
 
 # Default plugins
+ovos-vad-plugin-silero~=0.1
 ovos-ww-plugin-precise~=0.1
 ovos-ww-plugin-vosk~=0.1,>=0.1.1
 neon-stt-plugin-google-cloud-streaming~=1.0,>=1.0.1
 neon-tts-plugin-coqui-remote
-neon-stt-plugin-nemo~=0.0,>=0.0.3a3
+# neon-stt-plugin-nemo~=0.0,>=0.0.3a3
 
 # Fallback plugins
 neon-tts-plugin-coqui~=0.7,>=0.7.1
@@ -33,11 +34,12 @@ ovos-phal-plugin-balena-wifi~=1.0.0
 ovos-phal-plugin-gui-network-client~=0.0.2
 ovos-phal-plugin-network-manager~=1.0.0
 ovos-phal-plugin-wifi-setup~=1.1
+# TODO: Remove Dashboard after ovos-gui refactor
 ovos-phal-plugin-dashboard==0.0.2a3
 ovos-phal-plugin-alsa~=0.0.2
 ovos-phal-plugin-system~=0.0.3
 ovos-phal-plugin-connectivity-events~=0.0.2
-ovos-phal-plugin-homeassistant~=0.0.1,>=0.0.2a4
+ovos-phal-plugin-homeassistant~=0.0.2
 ovos-phal-plugin-ipgeo~=0.0.1
 # ovos-phal-plugin-gpsd @ git+https://github.com/OpenVoiceOS/ovos-PHAL-plugin-gpsd
 
@@ -49,4 +51,3 @@ ovos-skill-volume~=0.0.1
 
 # TODO: Below patching update bug
 # ovos-backend-client~=0.0.6
-neon-mq-connector~=0.6,>=0.6.1a9

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -9,7 +9,7 @@ neon-cli-client~=0.2
 neon-mana-utils~=0.0.4
 
 # Default plugins
-ovos-vad-plugin-silero~=0.1
+ovos-vad-plugin-silero~=0.0.1
 ovos-ww-plugin-precise~=0.1
 ovos-ww-plugin-vosk~=0.1,>=0.1.1
 neon-stt-plugin-google-cloud-streaming~=1.0,>=1.0.1

--- a/requirements/skills_default.txt
+++ b/requirements/skills_default.txt
@@ -14,5 +14,5 @@ neon-skill-weather~=0.1
 neon-skill-wikipedia~=0.4,>=0.4.1
 neon-skill-free_music_archive~=0.1,>=0.1.1
 neon-skill-local_music~=0.3
-neon-skill-holidays~=0.0.0a1
-neon-skill-fallback_llm~=0.0.1a4
+# neon-skill-holidays~=0.0.0a1
+neon-skill-fallback_llm~=0.0.1a6


### PR DESCRIPTION
# Description
Update default VAD engine to Silero for RPi
Update LLM skill to latest
Update stable Pi dependencies

# Issues
https://github.com/NeonGeckoCom/neon-image-recipe/pull/105 should be merged just before this

# Other Notes
WebRTC issue not fully diagnosed as it was not reproducible. Some installations error constantly with the following:
```
2023-06-06 16:34:24.136 - voice - ovos_dinkum_listener.voice_loop.voice_loop:_before_cmd:517 - ERROR - Error processing chunk of size=4096: Error while processing frame
Traceback (most recent call last):
  File "/home/neon/venv/lib/python3.7/site-packages/ovos_dinkum_listener/voice_loop/voice_loop.py", line 515, in _before_cmd
    self._chunk_info.is_speech = not self.vad.is_silence(stt_chunk)
  File "/home/neon/venv/lib/python3.7/site-packages/ovos_vad_plugin_webrtcvad/__init__.py", line 14, in is_silence
    return not self.vad.is_speech(chunk, self.sample_rate)
  File "/home/neon/venv/lib/python3.7/site-packages/webrtcvad.py", line 27, in is_speech
    return _webrtcvad.process(self._vad, sample_rate, buf, length)
webrtcvad.Error: Error while processing frame
```