### PR TITLE
Update Docker Config and Speech Dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL vendor=neon.ai \
 
 ENV OVOS_CONFIG_BASE_FOLDER neon
 ENV OVOS_CONFIG_FILENAME neon.yaml
+ENV XDG_CONFIG_HOME /config
 
 RUN  apt-get update && \
      apt-get install -y \

--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -67,6 +67,7 @@ sounds:
   start_listening: snd/start_listening.wav
   end_listening: snd/end_listening.wav
   acknowledge: snd/acknowledge.mp3
+  error: snd/error.mp3
 play_wav_cmdline: play %1
 play_mp3_cmdline: mpg123 %1
 play_ogg_cmdline: ogg123 -q %1
@@ -107,9 +108,12 @@ listener:
   recording_timeout_with_silence: 3.0
   instant_listen: false
   enable_stt_api: true
+  # amount of time to wait for speech to start after WW detection
   speech_begin: 0.5
+  # amount of time without speech to wait before stopping listening
   silence_end: 0.9
   # TODO: tune below params with WW disabled
+  # number of audio chunks from WW detection to include in STT audio
   utterance_chunks_to_rewind: 2
   wakeword_chunks_to_save: 15
 hotwords:

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,6 +1,6 @@
 # neon core modules
 neon_messagebus~=1.1,>=1.1.1a2
 neon_enclosure~=1.6
-neon_speech~=4.1
+neon_speech~=4.1,>=4.1.1a1
 neon_gui~=1.2
 neon_audio~=1.3,>=1.3.3a9


### PR DESCRIPTION
# Description
Set default XDG_CONFIG_HOME envvar in Dockerfile
Update neon-speech dependency
Update default speech config and add `error` sound to config

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->