### PR TITLE
Update default config handling for NeonOS

### DIFF
--- a/neon_core/configuration/mark_2/apps/ovos.common_play/settings.json
+++ b/neon_core/configuration/mark_2/apps/ovos.common_play/settings.json
@@ -1,0 +1,3 @@
+{
+  "app_view_timeout_mode": "pause"
+}

--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -1,0 +1,166 @@
+play_wav_cmdline: "play %1"
+play_mp3_cmdline: "play %1"
+play_ogg_cmdline: "play %1"
+g2p:
+  module: "dummy"
+tts:
+  module: neon-tts-plugin-coqui-remote
+  fallback_module: coqui
+  neon-tts-plugin-larynx-server:
+    host: "https://larynx.2022.us"
+  mozilla_remote:
+    api_url: "https://mtts.2022.us/api/tts"
+Audio:
+  backends:
+    OCP:
+      type: ovos_common_play
+      active: true
+      dbus_type: system
+audio_parsers:
+  blacklist:
+  - gender
+stt:
+  module: google_cloud_streaming
+  fallback_module: ovos-stt-plugin-vosk
+  ovos-stt-plugin-vosk:
+    model: /home/neon/.local/share/neon/vosk-model-small-en-us-0.15
+confirm_listening: true
+listener:
+  VAD:
+    silence_method: vad_only
+    module: ovos-vad-plugin-silero
+  mute_during_output: false
+  instant_listen: true
+  speech_begin: 0.5
+  silence_end: 0.9
+  utterance_chunks_to_rewind: 1
+hotwords:
+  wake_up:
+    active: false
+  hey_neon:
+    model_folder: /home/neon/.local/share/neon/vosk-model-small-en-us-0.15
+  hey_mycroft:
+    module: ovos-ww-plugin-precise-lite
+    model: https://github.com/OpenVoiceOS/precise-lite-models/raw/master/wakewords/en/hey_mycroft.tflite
+    listen: True
+    expected_duration: 3
+    trigger_level: 3
+    sensitivity: 0.5
+
+sounds:
+  start_listening: snd/start_listening.wav
+  acknowledge: snd/acknowledge.mp3
+gui_websocket:
+  host: 0.0.0.0
+  base_port: 18181
+  route: /gui
+  ssl: false
+websocket:
+  host: 0.0.0.0
+  port: 8181
+  route: /core
+  ssl: false
+  allow_self_signed: false
+  ssl_cert:
+  ssl_key:
+  shared_connection: true
+gui:
+  idle_display_skill: skill-ovos-homescreen.openvoiceos
+  extension: smartspeaker
+  run_gui_file_server: false
+  generic:
+    homescreen_supported: true
+MQ:
+  server: mq.2023.us
+  port: 35672
+  users:
+    mq_handler:
+      user: neon_api_utils
+      password: Klatchat2021
+signal:
+  use_signal_files: false
+skills:
+  blacklisted_skills:
+    - skill-ovos-setup.openvoiceos
+    - skill-messaging.neongeckocom
+    - skill-custom_conversation.neongeckocom
+    - skill-instructions.neongeckocom
+    - skill-audio_record.neongeckocom
+  # TODO: extra_directories here is the default, can it be removed?
+  extra_directories:
+    - /home/neon/.local/share/neon/skills
+  default_skills:
+  # TODO: Defaults are just patching skills not yet pip installable
+  - https://github.com/JarbasSkills/skill-icanhazdadjokes/tree/dev
+PHAL:
+  ovos-PHAL-plugin-balena-wifi:
+    enabled: false
+    debug: false
+    ssid: Neon
+    psk:
+    color: '#ff8600'
+    portal: start dot neon dot ai
+    device: Neon Device
+  ovos-PHAL-plugin-system:
+    core_service: neon.service
+  neon-phal-plugin-linear-led:
+    mute_color: burnt_orange
+    sleep_color: red
+    utterance_animation: refill
+  admin:
+    neon-phal-plugin-device-updater:
+      enabled: true
+      initramfs_url: "https://github.com/NeonGeckoCom/neon_debos/raw/dev/overlays/02-rpi4/boot/firmware/initramfs"
+      initramfs_path: /boot/firmware/initramfs
+      initramfs_update_path: /opt/neon/initramfs
+      squashfs_url: "https://2222.us/app/files/neon_images/pi/mycroft_mark_2/updates/"
+      squashfs_path: /opt/neon/update.squashfs
+    neon-phal-plugin-linear-led-neopixel:
+      enabled: true
+    neon-phal-plugin-core-updater:
+      enabled: true
+      update_command: systemctl start neon-updater
+      core_module: neon_core
+      github_ref: NeonGeckoCom/NeonCore
+    neon-phal-plugin-reset:
+      enabled: true
+      default_config_url: "https://github.com/NeonGeckoCom/NeonCore/archive/refs/tags/{}.zip"
+      default_config_path: configuration/mark_2
+ready_settings:
+  - skills
+  - voice
+  - audio
+  - gui_service
+  - internet
+  - network_skills
+  - internet_skills
+#  - setup
+server:
+  backend_type: offline
+
+# Logging Config
+log_dir: /home/neon/logs/
+log_level: INFO
+logs:
+  path: /home/neon/.local/state/neon/
+  max_bytes: 50000000
+  backup_count: 3
+  diagnostic: False
+  level_overrides:
+    error: []
+    warning:
+      - filelock
+      - botocore
+    info: []
+    debug: []
+debug: False
+system_unit: imperial
+system:
+  protected_keys:
+    remote:
+      - gui_websocket:host
+      - websocket:host
+      - ready_settings
+    user:
+      - gui_websocket:host
+      - websocket:host

--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -125,7 +125,7 @@ PHAL:
     neon-phal-plugin-reset:
       enabled: true
       default_config_url: "https://github.com/NeonGeckoCom/NeonCore/archive/refs/tags/{}.zip"
-      default_config_path: configuration/mark_2
+      default_config_path: neon_core/configuration/mark_2
 ready_settings:
   - skills
   - voice

--- a/neon_core/configuration/mark_2/skills/skill-demo.neongeckocom/settings.json
+++ b/neon_core/configuration/mark_2/skills/skill-demo.neongeckocom/settings.json
@@ -1,0 +1,5 @@
+{
+  "prompt_on_start": false,
+  "demo_tts_engine": "ovos-tts-plugin-mimic",
+  "__mycroft_skill_firstrun": false
+}

--- a/neon_core/configuration/mark_2/skills/skill-fallback_unknown.neongeckocom/settings.json
+++ b/neon_core/configuration/mark_2/skills/skill-fallback_unknown.neongeckocom/settings.json
@@ -1,0 +1,5 @@
+{
+  "emit_led": true,
+  "show_utterances": true,
+  "__mycroft_skill_firstrun": false
+}

--- a/neon_core/configuration/mark_2/skills/skill-instructions.neongeckocom/settings.json
+++ b/neon_core/configuration/mark_2/skills/skill-instructions.neongeckocom/settings.json
@@ -1,0 +1,4 @@
+{
+  "prompt_on_start": false,
+  "__mycroft_skill_firstrun": false
+}

--- a/neon_core/configuration/mark_2/skills/skill-local_music.neongeckocom/settings.json
+++ b/neon_core/configuration/mark_2/skills/skill-local_music.neongeckocom/settings.json
@@ -1,0 +1,4 @@
+{
+    "__mycroft_skill_firstrun": false,
+    "music_dir": "/media/sdb"
+}

--- a/neon_core/configuration/mark_2/skills/skill-ovos-homescreen.openvoiceos/settings.json
+++ b/neon_core/configuration/mark_2/skills/skill-ovos-homescreen.openvoiceos/settings.json
@@ -1,0 +1,10 @@
+{
+  "weather_skill": "skill-weather.neongeckocom",
+  "datetime_skill": "skill-date_time.neongeckocom",
+  "examples_skill": "skill-about.neongeckocom",
+  "wallpaper": "neon_default.jpg",
+  "persistent_menu_hint": true,
+  "examples_enabled": true,
+  "examples_prefix": false,
+  "__mycroft_skill_firstrun": false
+}

--- a/neon_core/configuration/mark_2/skills/skill-ovos-setup.openvoiceos/settings.json
+++ b/neon_core/configuration/mark_2/skills/skill-ovos-setup.openvoiceos/settings.json
@@ -1,0 +1,55 @@
+{
+    "enable_language_selection": false,
+    "enable_backend_selection": false,
+    "enable_stt_selection": false,
+    "enable_tts_selection": false,
+    "preferred_stt_engine": "deepspeech_stream_local",
+    "preferred_tts_engine": "coqui",
+    "tts_blacklist": [
+        "ovos-tts-plugin-SAM",
+        "ovos-tts-plugin-beepspeak",
+        "ovos_tts_plugin_espeakng"
+    ],
+    "stt_blacklist": [
+        "ovos-stt-plugin-pocketsphinx",
+        "ovos-stt-plugin-selene"
+    ],
+    "langs": [
+        {
+            "name": "English",
+            "code": "en",
+            "system_code": "en_US"
+        },
+        {
+            "name": "Italian",
+            "code": "it",
+            "system_code": "it_IT"
+        },
+        {
+            "name": "French",
+            "code": "fr",
+            "system_code": "fr_FR"
+        },
+        {
+            "name": "Spanish",
+            "code": "es",
+            "system_code": "es_ES"
+        },
+        {
+            "name": "Portuguese",
+            "code": "pt",
+            "system_code": "pt_PT"
+        },
+        {
+            "name": "German",
+            "code": "de",
+            "system_code": "de_DE"
+        },
+        {
+            "name": "Dutch",
+            "code": "nl",
+            "system_code": "nl_NL"
+        }
+    ],
+    "__mycroft_skill_firstrun": false
+}

--- a/neon_core/configuration/mark_2/skills/skill-user_settings.neongeckocom/settings.json
+++ b/neon_core/configuration/mark_2/skills/skill-user_settings.neongeckocom/settings.json
@@ -1,0 +1,4 @@
+{
+  "__mycroft_first_run": false,
+  "use_geolocation": true
+}

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -26,8 +26,9 @@ neon-tts-plugin-coqui~=0.7,>=0.7.1
 ovos-stt-plugin-vosk~=0.1,>=0.1.4
 
 # PHAL Plugins
-neon-phal-plugin-reset~=0.2,>=0.2.1
+neon-phal-plugin-reset~=0.2,>=0.2.2a1
 neon-phal-plugin-core-updater~=1.2,>=1.2.1
+neon-phal-plugin-device-updater~=0.0.0
 neon-phal-plugin-fan~=0.0.3
 neon-phal-plugin-switches~=0.0.4
 neon-phal-plugin-linear_led~=0.2,>=0.2.2

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -28,7 +28,7 @@ ovos-stt-plugin-vosk~=0.1,>=0.1.4
 # PHAL Plugins
 neon-phal-plugin-reset~=0.2,>=0.2.2a1
 neon-phal-plugin-core-updater~=1.2,>=1.2.1
-neon-phal-plugin-device-updater~=0.0.0
+neon-phal-plugin-device-updater~=0.0,>=0.0.1a2
 neon-phal-plugin-fan~=0.0.3
 neon-phal-plugin-switches~=0.0.4
 neon-phal-plugin-linear_led~=0.2,>=0.2.2


### PR DESCRIPTION
# Description
Moves default Mark2 configuration to NeonCore to keep default config in sync with core/dependency changes

# Issues
https://github.com/NeonGeckoCom/neon-phal-plugin-device-updater/pull/1
https://github.com/NeonGeckoCom/neon-phal-plugin-reset/pull/29

# Other Notes
PHAL Plugin dependencies should be updated with this change after validation on a Mark2 device