### PR TITLE
Use ramdisk for commonly accessed resource files on Mk2

### DIFF
--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -47,6 +47,7 @@ hotwords:
     trigger_level: 3
     sensitivity: 0.5
 
+data_dir: /ramdisk
 sounds:
   start_listening: snd/start_listening.wav
   acknowledge: snd/acknowledge.mp3


### PR DESCRIPTION
# Description
Add ramdisk datadir for mark2 to read resources from ramdisk if present

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->