### PR TITLE
Support pre-release OS and InitramFS update tracks

### DIFF
--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -110,10 +110,10 @@ PHAL:
   admin:
     neon-phal-plugin-device-updater:
       enabled: true
-      initramfs_url: "https://github.com/NeonGeckoCom/neon_debos/raw/dev/overlays/02-rpi4/boot/firmware/initramfs"
+      initramfs_url: "https://github.com/NeonGeckoCom/neon_debos/raw/{}/overlays/02-rpi4/boot/firmware/initramfs"
       initramfs_path: /opt/neon/firmware/initramfs
       initramfs_update_path: /opt/neon/initramfs
-      squashfs_url: "https://2222.us/app/files/neon_images/pi/mycroft_mark_2/updates/"
+      squashfs_url: "https://2222.us/app/files/neon_images/pi/mycroft_mark_2/updates/{}/"
       squashfs_path: /opt/neon/update.squashfs
     neon-phal-plugin-linear-led-neopixel:
       enabled: true

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -28,7 +28,7 @@ ovos-stt-plugin-vosk~=0.1,>=0.1.4
 # PHAL Plugins
 neon-phal-plugin-reset~=0.3
 neon-phal-plugin-core-updater~=1.2,>=1.2.1
-neon-phal-plugin-device-updater~=0.0,>=0.0.1a7
+neon-phal-plugin-device-updater~=0.0,>=0.0.1a8
 neon-phal-plugin-fan~=0.0.3
 neon-phal-plugin-switches~=0.0.4
 neon-phal-plugin-linear_led~=0.2,>=0.2.2
@@ -47,7 +47,7 @@ ovos-phal-plugin-ipgeo~=0.0.2
 ovos-gui-plugin-shell-companion~=0.0.0
 
 # Pi-specific skills
-neon-skill-update~=1.0,>=1.0.1a6
+neon-skill-update~=1.0,>=1.0.1a7
 ovos-skill-homescreen~=0.0.2,>=0.0.3a6
 ovos-skill-setup~=0.0.1
 ovos-skill-volume~=0.0.1


### PR DESCRIPTION
# Description
Skill and Update plugin support for configurable URLs
Update default Mark2 config to get dev/master releases for initramfs and squashfs updates

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->