### PR TITLE
Cleanup deprecated skill util references

### DIFF
--- a/docker_overlay/root/run.sh
+++ b/docker_overlay/root/run.sh
@@ -28,6 +28,6 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Python package installation must occur in a separate thread, before module load, for the entry point to be loaded.
-neon install-default-skills
-neon install-skill-requirements /skills  # TODO: Support xdg path
+#neon install-default-skills
+#neon install-skill-requirements /skills
 neon run-skills

--- a/neon_core/cli.py
+++ b/neon_core/cli.py
@@ -83,16 +83,16 @@ def install_default_skills():
     click.echo("Default Skills Installed")
 
 
-@neon_core_cli.command(help=
-                       "Install skill requirements for a specified directory")
-@click.argument("skill_dir")
-def install_skill_requirements(skill_dir):
-    from neon_core.util.skill_utils import install_local_skills
-    try:
-        installed = install_local_skills(skill_dir)
-        click.echo(f"Installed {len(installed)} skills from {skill_dir}")
-    except ValueError as e:
-        click.echo(e)
+# @neon_core_cli.command(help=
+#                        "Install skill requirements for a specified directory")
+# @click.argument("skill_dir")
+# def install_skill_requirements(skill_dir):
+#     from neon_core.util.skill_utils import install_local_skills
+#     try:
+#         installed = install_local_skills(skill_dir)
+#         click.echo(f"Installed {len(installed)} skills from {skill_dir}")
+#     except ValueError as e:
+#         click.echo(e)
 
 
 @neon_core_cli.command(help="Start Neon Skills module")
@@ -102,14 +102,15 @@ def run_skills(install_skills):
     from neon_utils.configuration_utils import init_config_dir
     init_config_dir()
 
-    from neon_core.util.skill_utils import install_local_skills
+    # from neon_core.util.skill_utils import install_local_skills
     from neon_core.skills.__main__ import main
     if install_skills:
-        click.echo(f"Handling installation of skills in: {install_skills}")
-        try:
-            install_local_skills(install_skills)
-        except ValueError as e:
-            click.echo(f"Skill Installation Failed: {e}")
+        click.echo(f"Local skill installation is deprecated. "
+                   f"Add pip specs to config.")
+        # try:
+        #     install_local_skills(install_skills)
+        # except ValueError as e:
+        #     click.echo(f"Skill Installation Failed: {e}")
     click.echo("Starting Skills Service")
     main()
     click.echo("Skills Service Shutdown")

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,6 +14,9 @@ ovos-plugin-manager~=0.0.21
 ovos-backend-client~=0.0.6
 psutil~=5.6
 
+click~=8.0
+click-default-group~=1.2
+
 # Used for patching skill settings
 mock~=5.0
 


### PR DESCRIPTION
# Description
Add missing `click` dependencies
Update run.sh and cli.py to account for removed skill installation helpers

# Issues
Fixes bug introduced in https://github.com/NeonGeckoCom/NeonCore/pull/555
# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->