### PR TITLE
Update dependencies to resolve skill init bugs

### DIFF
--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -8,5 +8,4 @@ neon_audio~=1.3,>=1.3.3a15
 # Troubleshooting version compat.
 ovos_plugin_common_play==0.0.6a2
 neon-utils[network]~=1.6,>=1.6.3a3
-ovos-plugin-manager>=0.0.24a12
 ovos-utils>=0.0.36a3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,14 +1,14 @@
-# mycroft
-ovos-core~=0.0.7
+# ovos-core version pinned for compat. with patches in NeonCore
+ovos-core==0.0.7
 # padacioso==0.1.3a2
 ovos-plugin-common-play~=0.0.5
 
 # utils
-neon-utils[audio,network]~=1.6,>=1.6.3a4
+neon-utils[audio,network]~=1.6,>=1.6.3a5
 # TODO: Audio extra patching dependency resolution
 ovos-utils~=0.0.35
-ovos-bus-client~=0.0.5,>=0.0.6a18
-# TODO: Above alpha just for testing compat.
+ovos-bus-client==0.0.5
+# TODO: Above pinned to reduce logs from ovos-core 0.0.7 with ovos-bus-client 0.0.6
 neon-transformers~=0.2
 ovos-config~=0.0.11
 ovos-plugin-manager~=0.0.21

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,7 +11,8 @@ ovos-bus-client==0.0.5
 # TODO: Above pinned to reduce logs from ovos-core 0.0.7 with ovos-bus-client 0.0.6
 neon-transformers~=0.2
 ovos-config~=0.0.11
-ovos-plugin-manager~=0.0.21
+ovos-plugin-manager~=0.0.21,>=0.0.24a18
+# Testing latest OPM
 ovos-backend-client~=0.0.6
 psutil~=5.6
 


### PR DESCRIPTION
# Description
Pins ovos-core version since 0.0.8 will need some patches updated for compat.
Pins ovos-bus-client to reduce log spam from ovos-core
Updates neon-utils to resolve CommonQuery and Fallback skill init
Updates ovos-plugin-manager to validate likely stable release version

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->