### PR TITLE
Refactor for compat. with latest ovos releases

### DIFF
--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -38,11 +38,11 @@ import ovos_workshop.skills
 ovos_workshop.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
 
 # TODO: Patch OVOS Skill?
-# workshop_modules = ("ovos_workshop.skills.ovos",
-#                     "ovos_workshop.skills.fallback",
-#                     "ovos_workshop.skills.common_query_skill",
-#                     "ovos_workshop.skills.common_play",
-#                     "ovos_workshop.skills")
+workshop_modules = ("ovos_workshop.skills.ovos",
+                    # "ovos_workshop.skills.fallback",
+                    # "ovos_workshop.skills.common_query_skill",
+                    # "ovos_workshop.skills.common_play",
+                    "ovos_workshop.skills")
 neon_utils_modules = ("neon_utils.skills.neon_fallback_skill",
                       "neon_utils.skills")
 mycroft_skills_modules = ("mycroft.skills.mycroft_skill.mycroft_skill",
@@ -53,12 +53,12 @@ mycroft_skills_modules = ("mycroft.skills.mycroft_skill.mycroft_skill",
                           "mycroft.skills.common_iot_skill",
                           "mycroft.skills")
 
-# # Reload ovos_workshop modules with Patched class
-# for module in workshop_modules:
-#     try:
-#         importlib.reload(importlib.import_module(module))
-#     except Exception as e:
-#         LOG.exception(e)
+# Reload ovos_workshop modules with Patched class
+for module in workshop_modules:
+    try:
+        importlib.reload(importlib.import_module(module))
+    except Exception as e:
+        LOG.exception(e)
 
 # Reload neon_utils modules with Patched class
 for module in neon_utils_modules:

--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -37,11 +37,12 @@ from neon_core.skills.decorators import intent_handler, intent_file_handler, \
 import ovos_workshop.skills
 ovos_workshop.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
 
-workshop_modules = ("ovos_workshop.skills.ovos",
-                    "ovos_workshop.skills.fallback",
-                    "ovos_workshop.skills.common_query_skill",
-                    "ovos_workshop.skills.common_play",
-                    "ovos_workshop.skills")
+# TODO: Patch OVOS Skill?
+# workshop_modules = ("ovos_workshop.skills.ovos",
+#                     "ovos_workshop.skills.fallback",
+#                     "ovos_workshop.skills.common_query_skill",
+#                     "ovos_workshop.skills.common_play",
+#                     "ovos_workshop.skills")
 neon_utils_modules = ("neon_utils.skills.neon_fallback_skill",
                       "neon_utils.skills")
 mycroft_skills_modules = ("mycroft.skills.mycroft_skill.mycroft_skill",
@@ -52,12 +53,12 @@ mycroft_skills_modules = ("mycroft.skills.mycroft_skill.mycroft_skill",
                           "mycroft.skills.common_iot_skill",
                           "mycroft.skills")
 
-# Reload ovos_workshop modules with Patched class
-for module in workshop_modules:
-    try:
-        importlib.reload(importlib.import_module(module))
-    except Exception as e:
-        LOG.exception(e)
+# # Reload ovos_workshop modules with Patched class
+# for module in workshop_modules:
+#     try:
+#         importlib.reload(importlib.import_module(module))
+#     except Exception as e:
+#         LOG.exception(e)
 
 # Reload neon_utils modules with Patched class
 for module in neon_utils_modules:

--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -39,9 +39,9 @@ ovos_workshop.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
 
 # TODO: Patch OVOS Skill?
 workshop_modules = ("ovos_workshop.skills.ovos",
-                    # "ovos_workshop.skills.fallback",
-                    # "ovos_workshop.skills.common_query_skill",
-                    # "ovos_workshop.skills.common_play",
+                    "ovos_workshop.skills.fallback",
+                    "ovos_workshop.skills.common_query_skill",
+                    "ovos_workshop.skills.common_play",
                     "ovos_workshop.skills")
 neon_utils_modules = ("neon_utils.skills.neon_fallback_skill",
                       "neon_utils.skills")

--- a/neon_core/skills/service.py
+++ b/neon_core/skills/service.py
@@ -41,12 +41,11 @@ from neon_utils.metrics_utils import announce_connection
 from neon_utils.signal_utils import init_signal_handlers, init_signal_bus
 from neon_utils.messagebus_utils import get_messagebus
 from ovos_bus_client.util.scheduler import EventScheduler
-from ovos_utils.skills.api import SkillApi
+from ovos_workshop.skills.api import SkillApi
 from ovos_workshop.skills.fallback import FallbackSkill
 
 from neon_core.skills.intent_service import NeonIntentService
 from neon_core.skills.skill_manager import NeonSkillManager
-from neon_core.util.diagnostic_utils import report_metric
 
 
 def on_started():

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,6 +1,6 @@
 # neon core modules
 neon_messagebus~=2.0,>=2.0.1a1
-neon_enclosure~=1.6,>=1.6.1
+neon_enclosure~=1.6,>=1.6.2a1
 neon_speech~=4.3
 neon_gui~=1.2,>=1.2.2
-neon_audio~=1.5
+neon_audio~=1.5,>=1.5.1a1

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -42,7 +42,7 @@ ovos-phal-plugin-balena-wifi~=1.0.0
 neon-phal-plugin-gui-network-client~=0.0.3
 ovos-phal-plugin-network-manager~=1.1
 ovos-phal-plugin-wifi-setup~=1.1,>=1.1.1
-ovos-phal-plugin-oauth~=0.0.2
+ovos-phal-plugin-oauth~=0.0.2,>=0.0.3a1
 ovos-phal-plugin-alsa~=0.0.3
 ovos-phal-plugin-system~=0.0.4
 ovos-phal-plugin-connectivity-events~=0.0.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,8 @@
 # ovos-core version pinned for compat. with patches in NeonCore
 ovos-core==0.0.7
 # padacioso==0.1.3a2
-ovos-plugin-common-play~=0.0.5,>=0.0.6a11
+# ovos-plugin-common-play~=0.0.5,>=0.0.6a11
+ovos-plugin-common-play@git+https://github.com/openvoiceos/ovos-ocp-audio-plugin@ORG_LoosenDependencies
 
 # TODO: Audio for alpha resolution
 neon-utils[network,audio]~=1.8,>=1.8.3a1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 # ovos-core version pinned for compat. with patches in NeonCore
 ovos-core==0.0.7
 # padacioso==0.1.3a2
-ovos-plugin-common-play~=0.0.5,>0.0.6a11
+ovos-plugin-common-play~=0.0.5,>=0.0.6a11
 
 # TODO: Audio for alpha resolution
 neon-utils[network,audio]~=1.8,>=1.8.3a1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,8 @@ ovos-core==0.0.7
 # padacioso==0.1.3a2
 ovos-plugin-common-play~=0.0.5
 
-neon-utils[network]~=1.8,>=1.8.2
+# TODO: Audio for alpha resolution
+neon-utils[network,audio]~=1.8,>=1.8.3a1
 
 ovos-utils~=0.0.38
 ovos-bus-client~=0.0.8

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,8 +4,7 @@ ovos-core==0.0.7
 ovos-plugin-common-play~=0.0.5,>=0.0.6a13
 
 # TODO: Audio for alpha resolution
-# neon-utils[network,audio]~=1.8,>=1.8.3a1
-neon-utils[network,audio]@git+https://github.com/neongeckocom/neon-utils@FIX_FallbackSkillInit
+neon-utils[network,audio]~=1.8,>=1.8.3a2
 
 ovos-utils~=0.0.38
 ovos-bus-client~=0.0.8

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,11 +1,11 @@
 # ovos-core version pinned for compat. with patches in NeonCore
 ovos-core==0.0.7
 # padacioso==0.1.3a2
-# ovos-plugin-common-play~=0.0.5,>=0.0.6a11
-ovos-plugin-common-play@git+https://github.com/openvoiceos/ovos-ocp-audio-plugin@ORG_LoosenDependencies
+ovos-plugin-common-play~=0.0.5,>=0.0.6a13
 
 # TODO: Audio for alpha resolution
-neon-utils[network,audio]~=1.8,>=1.8.3a1
+# neon-utils[network,audio]~=1.8,>=1.8.3a1
+neon-utils[network,audio]@git+https://github.com/neongeckocom/neon-utils@FIX_FallbackSkillInit
 
 ovos-utils~=0.0.38
 ovos-bus-client~=0.0.8

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,7 @@ ovos-bus-client~=0.0.8
 neon-transformers~=0.2
 ovos-config~=0.0.12
 ovos-plugin-manager~=0.0.25
-ovos-backend-client~=0.1
+ovos-backend-client~=0.1,>=0.1.1a2
 psutil~=5.6
 
 click~=8.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,13 +5,12 @@ ovos-plugin-common-play~=0.0.5
 
 neon-utils[network]~=1.8,>=1.8.2
 
-ovos-utils~=0.0.37
+ovos-utils~=0.0.38
 ovos-bus-client~=0.0.8
 neon-transformers~=0.2
 ovos-config~=0.0.12
 ovos-plugin-manager~=0.0.25
-# Testing latest OPM
-ovos-backend-client~=0.0.6
+ovos-backend-client~=0.1
 psutil~=5.6
 
 click~=8.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 # ovos-core version pinned for compat. with patches in NeonCore
 ovos-core==0.0.7
 # padacioso==0.1.3a2
-ovos-plugin-common-play~=0.0.5
+ovos-plugin-common-play~=0.0.5,>0.0.6a11
 
 # TODO: Audio for alpha resolution
 neon-utils[network,audio]~=1.8,>=1.8.3a1

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -202,7 +202,8 @@ class SkillUtilsTests(unittest.TestCase):
         self.assertEqual(FallbackSkill1, FallbackSkill)
         self.assertEqual(FallbackSkill2, FallbackSkill)
 
-        self.assertTrue(issubclass(FallbackSkill, PatchedMycroftSkill))
+        from neon_utils.skills.neon_skill import NeonSkill
+        self.assertTrue(issubclass(FallbackSkill, NeonSkill))
         self.assertTrue(issubclass(CommonPlaySkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonIoTSkill, PatchedMycroftSkill))

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -203,7 +203,7 @@ class SkillUtilsTests(unittest.TestCase):
         self.assertEqual(FallbackSkill2, FallbackSkill)
 
         from neon_utils.skills.neon_skill import NeonSkill
-        self.assertTrue(issubclass(FallbackSkill, NeonSkill))
+        # self.assertTrue(issubclass(FallbackSkill, NeonSkill))
         self.assertTrue(issubclass(CommonPlaySkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonIoTSkill, PatchedMycroftSkill))
@@ -221,10 +221,10 @@ class SkillUtilsTests(unittest.TestCase):
         self.assertEqual(OVOSSkill, OVOSSkill2)
 
         from neon_utils.skills import NeonFallbackSkill, NeonSkill
-        self.assertTrue(issubclass(NeonFallbackSkill, PatchedMycroftSkill))
+        # self.assertTrue(issubclass(NeonFallbackSkill, PatchedMycroftSkill))
         # self.assertTrue(issubclass(NeonSkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(NeonFallbackSkill, OVOSSkill))
-        self.assertTrue(issubclass(NeonFallbackSkill, NeonSkill))
+        # self.assertTrue(issubclass(NeonFallbackSkill, NeonSkill))
 
         from neon_utils.skills.neon_fallback_skill import NeonFallbackSkill as \
             NeonFallbackSkill2

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -232,16 +232,16 @@ class SkillUtilsTests(unittest.TestCase):
         self.assertEqual(NeonFallbackSkill, NeonFallbackSkill2)
         self.assertEqual(NeonSkill, NeonSkill2)
 
-        from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
-        self.assertTrue(issubclass(OVOSCommonPlaybackSkill,
-                                   PatchedMycroftSkill))
-
-        try:
-            from ovos_workshop.skills.common_query_skill import CommonQuerySkill
-            self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
-        except ModuleNotFoundError:
-            # Class added in ovos-workwhop 0.0.12
-            pass
+        # from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
+        # self.assertTrue(issubclass(OVOSCommonPlaybackSkill,
+        #                            PatchedMycroftSkill))
+        #
+        # try:
+        #     from ovos_workshop.skills.common_query_skill import CommonQuerySkill
+        #     self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
+        # except ModuleNotFoundError:
+        #     # Class added in ovos-workwhop 0.0.12
+        #     pass
 
 
 if __name__ == '__main__':

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -210,10 +210,10 @@ class SkillUtilsTests(unittest.TestCase):
 
         from ovos_workshop.skills.mycroft_skill import MycroftSkill as Patched
         from ovos_workshop.skills import MycroftSkill as Patched2
-        from ovos_workshop.skills.ovos import MycroftSkill as Patched3
+        # from ovos_workshop.skills.ovos import MycroftSkill as Patched3
         self.assertEqual(Patched, PatchedMycroftSkill)
         self.assertEqual(Patched2, PatchedMycroftSkill)
-        self.assertEqual(Patched3, PatchedMycroftSkill)
+        # self.assertEqual(Patched3, PatchedMycroftSkill)
 
         from ovos_workshop.skills.ovos import OVOSSkill
         from ovos_workshop.skills import OVOSSkill as OVOSSkill2

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -217,7 +217,7 @@ class SkillUtilsTests(unittest.TestCase):
 
         from ovos_workshop.skills.ovos import OVOSSkill
         from ovos_workshop.skills import OVOSSkill as OVOSSkill2
-        self.assertTrue(issubclass(OVOSSkill, PatchedMycroftSkill))
+        # self.assertTrue(issubclass(OVOSSkill, PatchedMycroftSkill))
         self.assertEqual(OVOSSkill, OVOSSkill2)
 
         from neon_utils.skills import NeonFallbackSkill, NeonSkill


### PR DESCRIPTION
# Description
Replace deprecated imports
Update neon-utils to resolve ovos-workshop deprecation warnings
Update ovos-backend-client dependency to support latest releases
Deprecate patching of some skill classes in `ovos-workshop`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
The refactoring in `ovos-workshop` means that `fallback`, `common_query`, and `common_play` skills will no longer have patches applied from neon-utils. This hasn't been fully tested but the following regressions may occur when using non-`NeonSkill` skills:
- `location` will no longer use user profile data
- `get_response` may not behave as expected in multi-user environments
- `speak`/`speak_dialog` calls may not have the same timing context available and may not be compatible with server implementations
- skill settings may not populate from `settingsmeta.yml` without a backend configured