### PR TITLE
Add support for Mark1 enclosure

### DIFF
--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -91,6 +91,8 @@ skills:
     - skill-audio_record.neongeckocom
   default_skills: []
 PHAL:
+  ovos-PHAL-plugin-mk1:
+    enabled: false
   ovos-PHAL-plugin-balena-wifi:
     enabled: false
     debug: false

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -47,6 +47,8 @@ ovos-phal-plugin-connectivity-events~=0.0.3
 ovos-phal-plugin-homeassistant~=0.0.3,>=0.0.4a5
 ovos-phal-plugin-wallpaper-manager~=0.0.1
 ovos-phal-plugin-ipgeo~=0.0.2
+ovos-phal-plugin-mk1 @ git+https://github.com/openvoiceos/ovos-phal-plugin-mk1@dev
+# TODO: Stable spec for mk1 plugin
 # ovos-phal-plugin-gpsd @ git+https://github.com/OpenVoiceOS/ovos-PHAL-plugin-gpsd
 ovos-gui-plugin-shell-companion~=0.0.0,>=0.0.1a4
 


### PR DESCRIPTION
# Description
Add Mark1 PHAL plugin to Pi dependencies
Disable Mark1 PHAL plugin in Mark2 config

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Note that the added plugin is [disabled by default](https://github.com/NeonGeckoCom/NeonCore/pull/617/files#diff-85bcaebfa6b160440eef7d305191a160b4be49acda5e8777eb254f08d9ec5e58R94-R95) in Mark2 images