### PR TITLE
fix: pin openwakeword version

### DIFF
--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -16,6 +16,7 @@ onnxruntime!=1.16.0  # TODO: Patching https://github.com/microsoft/onnxruntime/i
 ovos-ww-plugin-precise~=0.1
 ovos-ww-plugin-precise-lite[tflite]~=0.1,>=0.1.2
 ovos-ww-plugin-vosk~=0.1,>=0.1.1
+openwakeword~=0.5,<0.6
 ovos-ww-plugin-openwakeword~=0.2
 neon-stt-plugin-google-cloud-streaming~=1.0,>=1.0.1
 

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -16,6 +16,7 @@ onnxruntime!=1.16.0  # TODO: Patching https://github.com/microsoft/onnxruntime/i
 ovos-ww-plugin-precise~=0.1
 ovos-ww-plugin-precise-lite[tflite]~=0.1,>=0.1.2
 ovos-ww-plugin-vosk~=0.1,>=0.1.1
+# patching breaking change in openeakeword
 openwakeword~=0.5,<0.6
 ovos-ww-plugin-openwakeword~=0.2
 neon-stt-plugin-google-cloud-streaming~=1.0,>=1.0.1

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -17,6 +17,7 @@ ovos-ww-plugin-precise~=0.1
 ovos-ww-plugin-precise-lite[tflite]~=0.1,>=0.1.2
 ovos-ww-plugin-vosk~=0.1,>=0.1.1
 # patching breaking change in openeakeword
+# patching breaking change in openeakeword
 openwakeword~=0.5,<0.6
 ovos-ww-plugin-openwakeword~=0.2
 neon-stt-plugin-google-cloud-streaming~=1.0,>=1.0.1

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -17,7 +17,6 @@ ovos-ww-plugin-precise~=0.1
 ovos-ww-plugin-precise-lite[tflite]~=0.1,>=0.1.2
 ovos-ww-plugin-vosk~=0.1,>=0.1.1
 # patching breaking change in openeakeword
-# patching breaking change in openeakeword
 openwakeword~=0.5,<0.6
 ovos-ww-plugin-openwakeword~=0.2
 neon-stt-plugin-google-cloud-streaming~=1.0,>=1.0.1


### PR DESCRIPTION
# Description
https://github.com/OpenVoiceOS/ovos-ww-plugin-openWakeWord/issues/7

Without pinning this, openwakeword models don't work properly.

# Other Notes
If people intend to try the hey_neon OpenWW models, this needs to be in place until the issue linked above is fixed.