### PR TITLE
chore: enable config flag to disable HA intents

### DIFF
--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -109,6 +109,8 @@ PHAL:
     utterance_animation: refill
   neon-phal-plugin-fan:
     min_fan_temp: 40.0
+  ovos-PHAL-plugin-homeassistant:
+    disable_intents: true
   admin:
     neon-phal-plugin-device-updater:
       enabled: true


### PR DESCRIPTION
# Description
Flips the feature flag for disabling HA intent when HA isn't connected to "on."

# Issues
https://github.com/mikejgray/neon-homeassistant-skill/issues/38

# Other Notes
Pairs with https://github.com/mikejgray/neon-homeassistant-skill/pull/39, but won't do anything if this isn't available.