### PR TITLE
Remove MycroftSkill class patching

### DIFF
--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -29,6 +29,11 @@
 from neon_core.skills.decorators import intent_handler, intent_file_handler, \
     resting_screen_handler, conversational_intent
 
+# TODO: Remove below patches with ovos-core 0.0.8 refactor
+import neon_core.skills.patched_plugin_loader
+import neon_core.skills.patched_skill_settings
+import neon_core.skills.patched_common_query
+
 import mycroft.skills
 from mycroft.skills import api
 from mycroft.skills import skill_manager

--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -33,17 +33,7 @@ from neon_utils.skills.mycroft_skill import PatchedMycroftSkill
 from neon_core.skills.decorators import intent_handler, intent_file_handler, \
     resting_screen_handler, conversational_intent
 
-# Patch the base skill
-import ovos_workshop.skills
-ovos_workshop.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
-
-workshop_modules = ("ovos_workshop.skills.ovos",
-                    "ovos_workshop.skills.fallback",
-                    "ovos_workshop.skills.common_query_skill",
-                    "ovos_workshop.skills.common_play",
-                    "ovos_workshop.skills")
-neon_utils_modules = ("neon_utils.skills.neon_fallback_skill",
-                      "neon_utils.skills")
+# TODO: Remove below patches with ovos-core 0.0.8 refactor
 mycroft_skills_modules = ("mycroft.skills.mycroft_skill.mycroft_skill",
                           "mycroft.skills.mycroft_skill",
                           "mycroft.skills.fallback_skill",
@@ -51,20 +41,6 @@ mycroft_skills_modules = ("mycroft.skills.mycroft_skill.mycroft_skill",
                           "mycroft.skills.common_query_skill",
                           "mycroft.skills.common_iot_skill",
                           "mycroft.skills")
-
-# Reload ovos_workshop modules with Patched class
-for module in workshop_modules:
-    try:
-        importlib.reload(importlib.import_module(module))
-    except Exception as e:
-        LOG.exception(e)
-
-# Reload neon_utils modules with Patched class
-for module in neon_utils_modules:
-    try:
-        importlib.reload(importlib.import_module(module))
-    except Exception as e:
-        LOG.exception(e)
 
 # Reload mycroft modules with Patched class
 for module in mycroft_skills_modules:
@@ -83,7 +59,6 @@ import mycroft.skills.core
 mycroft.skills.core.MycroftSkill = PatchedMycroftSkill
 mycroft.skills.core.FallbackSkill = mycroft.skills.fallback_skill.FallbackSkill
 
-# TODO: Remove below patches with ovos-core 0.0.8 refactor
 import neon_core.skills.patched_plugin_loader
 import neon_core.skills.patched_skill_settings
 import neon_core.skills.patched_common_query

--- a/neon_core/skills/__init__.py
+++ b/neon_core/skills/__init__.py
@@ -26,43 +26,10 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import importlib
-
-from ovos_utils.log import LOG
-from neon_utils.skills.mycroft_skill import PatchedMycroftSkill
 from neon_core.skills.decorators import intent_handler, intent_file_handler, \
     resting_screen_handler, conversational_intent
 
-# TODO: Remove below patches with ovos-core 0.0.8 refactor
-mycroft_skills_modules = ("mycroft.skills.mycroft_skill.mycroft_skill",
-                          "mycroft.skills.mycroft_skill",
-                          "mycroft.skills.fallback_skill",
-                          "mycroft.skills.common_play_skill",
-                          "mycroft.skills.common_query_skill",
-                          "mycroft.skills.common_iot_skill",
-                          "mycroft.skills")
-
-# Reload mycroft modules with Patched class
-for module in mycroft_skills_modules:
-    try:
-        importlib.reload(importlib.import_module(module))
-    except Exception as e:
-        LOG.exception(e)
-
-# Manually patch top-level `mycroft` references
-import mycroft
-mycroft.MycroftSkill = PatchedMycroftSkill
-mycroft.FallbackSkill = mycroft.skills.fallback_skill.FallbackSkill
-
-# Manually patch re-defined classes in `mycroft.skills.core`
-import mycroft.skills.core
-mycroft.skills.core.MycroftSkill = PatchedMycroftSkill
-mycroft.skills.core.FallbackSkill = mycroft.skills.fallback_skill.FallbackSkill
-
-import neon_core.skills.patched_plugin_loader
-import neon_core.skills.patched_skill_settings
-import neon_core.skills.patched_common_query
-
+import mycroft.skills
 from mycroft.skills import api
 from mycroft.skills import skill_manager
 from mycroft.skills.intent_services import padatious_service, converse_service

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -211,46 +211,13 @@ class SkillUtilsTests(unittest.TestCase):
         self.assertEqual(FallbackSkill1, FallbackSkill)
         self.assertEqual(FallbackSkill2, FallbackSkill)
 
-        from neon_utils.skills.neon_skill import NeonSkill
-        # self.assertTrue(issubclass(FallbackSkill, NeonSkill))
         self.assertTrue(issubclass(CommonPlaySkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonIoTSkill, PatchedMycroftSkill))
 
-        from ovos_workshop.skills.mycroft_skill import MycroftSkill as Patched
-        from ovos_workshop.skills import MycroftSkill as Patched2
-        # from ovos_workshop.skills.ovos import MycroftSkill as Patched3
-        self.assertEqual(Patched, PatchedMycroftSkill)
-        self.assertEqual(Patched2, PatchedMycroftSkill)
-        # self.assertEqual(Patched3, PatchedMycroftSkill)
-
         from ovos_workshop.skills.ovos import OVOSSkill
-        from ovos_workshop.skills import OVOSSkill as OVOSSkill2
-        # self.assertTrue(issubclass(OVOSSkill, PatchedMycroftSkill))
-        self.assertEqual(OVOSSkill, OVOSSkill2)
-
         from neon_utils.skills import NeonFallbackSkill, NeonSkill
-        # self.assertTrue(issubclass(NeonFallbackSkill, PatchedMycroftSkill))
-        # self.assertTrue(issubclass(NeonSkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(NeonFallbackSkill, OVOSSkill))
-        # self.assertTrue(issubclass(NeonFallbackSkill, NeonSkill))
-
-        from neon_utils.skills.neon_fallback_skill import NeonFallbackSkill as \
-            NeonFallbackSkill2
-        from neon_utils.skills.neon_skill import NeonSkill as NeonSkill2
-        self.assertEqual(NeonFallbackSkill, NeonFallbackSkill2)
-        self.assertEqual(NeonSkill, NeonSkill2)
-
-        # from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
-        # self.assertTrue(issubclass(OVOSCommonPlaybackSkill,
-        #                            PatchedMycroftSkill))
-        #
-        # try:
-        #     from ovos_workshop.skills.common_query_skill import CommonQuerySkill
-        #     self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
-        # except ModuleNotFoundError:
-        #     # Class added in ovos-workwhop 0.0.12
-        #     pass
 
     @patch("neon_core.util.skill_utils.Configuration")
     def test_update_default_resources(self, config):

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -189,6 +189,7 @@ class SkillUtilsTests(unittest.TestCase):
     #     self.assertEqual(ovos_skills_manager.requirements.DEFAULT_CONSTRAINTS,
     #                      __file__)
 
+    @skip("Skill class patching is deprecated")
     def test_skill_class_patches(self):
         import neon_core.skills  # Import to do all the patching
         from neon_utils.skills.mycroft_skill import PatchedMycroftSkill

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -212,14 +212,46 @@ class SkillUtilsTests(unittest.TestCase):
         self.assertEqual(FallbackSkill1, FallbackSkill)
         self.assertEqual(FallbackSkill2, FallbackSkill)
 
+        from neon_utils.skills.neon_skill import NeonSkill
+        # self.assertTrue(issubclass(FallbackSkill, NeonSkill))
         self.assertTrue(issubclass(CommonPlaySkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(CommonIoTSkill, PatchedMycroftSkill))
 
+        from ovos_workshop.skills.mycroft_skill import MycroftSkill as Patched
+        from ovos_workshop.skills import MycroftSkill as Patched2
+        # from ovos_workshop.skills.ovos import MycroftSkill as Patched3
+        self.assertEqual(Patched, PatchedMycroftSkill)
+        self.assertEqual(Patched2, PatchedMycroftSkill)
+        # self.assertEqual(Patched3, PatchedMycroftSkill)
+
         from ovos_workshop.skills.ovos import OVOSSkill
+        from ovos_workshop.skills import OVOSSkill as OVOSSkill2
+        # self.assertTrue(issubclass(OVOSSkill, PatchedMycroftSkill))
+        self.assertEqual(OVOSSkill, OVOSSkill2)
+
         from neon_utils.skills import NeonFallbackSkill, NeonSkill
+        # self.assertTrue(issubclass(NeonFallbackSkill, PatchedMycroftSkill))
+        # self.assertTrue(issubclass(NeonSkill, PatchedMycroftSkill))
         self.assertTrue(issubclass(NeonFallbackSkill, OVOSSkill))
-        self.assertTrue(issubclass(NeonSkill, OVOSSkill))
+        # self.assertTrue(issubclass(NeonFallbackSkill, NeonSkill))
+
+        from neon_utils.skills.neon_fallback_skill import NeonFallbackSkill as \
+            NeonFallbackSkill2
+        from neon_utils.skills.neon_skill import NeonSkill as NeonSkill2
+        self.assertEqual(NeonFallbackSkill, NeonFallbackSkill2)
+        self.assertEqual(NeonSkill, NeonSkill2)
+
+        # from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
+        # self.assertTrue(issubclass(OVOSCommonPlaybackSkill,
+        #                            PatchedMycroftSkill))
+        #
+        # try:
+        #     from ovos_workshop.skills.common_query_skill import CommonQuerySkill
+        #     self.assertTrue(issubclass(CommonQuerySkill, PatchedMycroftSkill))
+        # except ModuleNotFoundError:
+        #     # Class added in ovos-workwhop 0.0.12
+        #     pass
 
     @patch("neon_core.util.skill_utils.Configuration")
     def test_update_default_resources(self, config):

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -218,6 +218,7 @@ class SkillUtilsTests(unittest.TestCase):
         from ovos_workshop.skills.ovos import OVOSSkill
         from neon_utils.skills import NeonFallbackSkill, NeonSkill
         self.assertTrue(issubclass(NeonFallbackSkill, OVOSSkill))
+        self.assertTrue(issubclass(NeonSkill, OVOSSkill))
 
     @patch("neon_core.util.skill_utils.Configuration")
     def test_update_default_resources(self, config):


### PR DESCRIPTION
# Description
Deprecates patching of `ovos_workshop` modules now that those implement `OVOSSkill` directly
Marks `mycroft` namespace patching as deprecated by ovos-core 0.0.8 which will already reference OVOSSkill in those places

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This will need some amount of manual validation against an OVOSSkill (and possibly MycroftSkill).
The HomeAssistant skill is included by default and can be used to validate this change.