### PR TITLE
Remove entrypoints and helpers marked for deprecation

### DIFF
--- a/neon_core/run_neon.py
+++ b/neon_core/run_neon.py
@@ -35,7 +35,7 @@ from signal import SIGTERM
 from threading import Event
 from subprocess import Popen, STDOUT
 from ovos_bus_client import MessageBusClient, Message
-from typing.io import IO
+from typing import IO
 
 from neon_utils.configuration_utils import init_config_dir
 init_config_dir()

--- a/neon_core/util/diagnostic_utils.py
+++ b/neon_core/util/diagnostic_utils.py
@@ -118,21 +118,3 @@ def send_diagnostics(allow_logs=True, allow_transcripts=True, allow_config=True)
             "transcripts": transcripts}
     report_metric("diagnostics", **data)
     return data
-
-
-def cli_send_diags():
-    """
-    CLI Entry Point to Send Diagnostics
-    """
-    LOG.warning(f"This function is deprecated. Use `neon upload-diagnostics`")
-    import argparse
-    parser = argparse.ArgumentParser(description="Upload Neon Diagnostics Files", add_help=True)
-    parser.add_argument("--no-transcripts", dest="transcripts", default=True, action='store_false',
-                        help="Disable upload of all transcribed input")
-    parser.add_argument("--no-logs", dest="logs", default=True, action='store_false',
-                        help="Disable upload of Neon log files (NOTE: start_neon.log is always uploaded)")
-    parser.add_argument("--no-config", dest="config", default=True, action='store_false',
-                        help="Disable upload of Neon config files")
-
-    args = parser.parse_args()
-    send_diagnostics(args.logs, args.transcripts, args.config)

--- a/setup.py
+++ b/setup.py
@@ -110,13 +110,7 @@ setup(
     include_package_data=True,
     entry_points={
         'console_scripts': [
-            'neon=neon_core.cli:neon_core_cli',
-            # TODO: Deprecate below entrypoints
-            'neon_skills_service=neon_core.skills.__main__:main',
-            'neon-install-default-skills=neon_core.util.skill_utils:install_skills_default',
-            'neon-upload-diagnostics=neon_core.util.diagnostic_utils:cli_send_diags',
-            'neon-start=neon_core.run_neon:start_neon',
-            'neon-stop=neon_core.run_neon:stop_neon'
+            'neon=neon_core.cli:neon_core_cli'
         ]
     }
 )


### PR DESCRIPTION
# Description
Updates `run_neon.py` for Python3.10 compat.
Removes deprecated `cli_send_diags` helper
Removes deprecated shell entrypoints

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->