### PR TITLE
Deprecate non-pip installation helpers

### DIFF
--- a/docker_overlay/root/run.sh
+++ b/docker_overlay/root/run.sh
@@ -29,5 +29,4 @@
 
 # Python package installation must occur in a separate thread, before module load, for the entry point to be loaded.
 neon install-default-skills
-#neon install-skill-requirements /skills
 neon run-skills

--- a/neon_core/cli.py
+++ b/neon_core/cli.py
@@ -89,17 +89,6 @@ def update_default_resources():
     click.echo("Updating Default Resources")
     update_default_resources()
 
-# @neon_core_cli.command(help=
-#                        "Install skill requirements for a specified directory")
-# @click.argument("skill_dir")
-# def install_skill_requirements(skill_dir):
-#     from neon_core.util.skill_utils import install_local_skills
-#     try:
-#         installed = install_local_skills(skill_dir)
-#         click.echo(f"Installed {len(installed)} skills from {skill_dir}")
-#     except ValueError as e:
-#         click.echo(e)
-
 
 @neon_core_cli.command(help="Start Neon Skills module")
 @click.option("--install-skills", "-i", default=None,

--- a/neon_core/util/skill_utils.py
+++ b/neon_core/util/skill_utils.py
@@ -27,7 +27,6 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
-import os.path
 import re
 
 from copy import copy
@@ -53,7 +52,8 @@ def get_neon_skills_data(skill_meta_repository: str =
     :param branch: branch of repository to check out
     :param repo_metadata_path: Path to repo directory containing json metadata files
     """
-    log_deprecation("This skill repository format is deprecated; specify skills as packages")
+    log_deprecation("This skill repository format is deprecated; "
+                    "specify skills as packages", "24.04")
     from ovos_skills_manager.github import normalize_github_url, download_url_from_github_url
     from ovos_skill_installer import download_extract_zip
     skills_data = dict()
@@ -75,14 +75,12 @@ def get_neon_skills_data(skill_meta_repository: str =
     return skills_data
 
 
-def _write_pip_constraints_to_file(output_file: str = None):
+def _write_pip_constraints_to_file(output_file):
     """
     Writes out a constraints file for OSM to use to prevent broken dependencies
     :param output_file: path to constraints file to write
     """
     from neon_utils.packaging_utils import get_package_dependencies
-    # TODO: Backwards-compat to be deprecated
-    output_file = output_file or '/etc/mycroft/constraints.txt'
     if not isdir(dirname(output_file)):
         makedirs(dirname(output_file))
 
@@ -102,46 +100,6 @@ def _write_pip_constraints_to_file(output_file: str = None):
     LOG.info(f"Wrote core constraints to file: {output_file}")
 
 
-def _install_skill_osm(skill_url: str, skill_dir: str, skills_catalog: dict):
-    """
-    Install a skill from source using OVOS Skills Manager
-    :param skill_url: URL of skill to install
-    :param skill_dir: Directory to install skill to
-    :param skills_catalog: dict Neon skill information (url to dict data)
-    """
-    from ovos_skills_manager.osm import OVOSSkillsManager
-    from ovos_skills_manager.skill_entry import SkillEntry
-    from ovos_skills_manager.github import normalize_github_url, get_branch_from_github_url
-    log_deprecation("Update all skills to `pip`-installable specs.")
-    osm = OVOSSkillsManager()
-    try:
-        normalized_url = normalize_github_url(skill_url)
-        # Check if this skill is in the Neon list
-        if normalized_url in skills_catalog:
-            branch = get_branch_from_github_url(skill_url)
-            # Set URL and branch to requested spec
-            skills_catalog[normalized_url]["url"] = normalized_url
-            skills_catalog[normalized_url]["branch"] = branch
-            entry = SkillEntry.from_json(skills_catalog.get(normalized_url), False)
-        else:
-            LOG.warning(f"Requested Skill not in Neon skill store ({skill_url})")
-            entry = osm.skill_entry_from_url(skill_url)
-            LOG.debug(entry.json)
-
-        osm.install_skill(entry, skill_dir)
-        if not os.path.isdir(os.path.join(skill_dir, entry.uuid)):
-            LOG.error(f"Failed to install: "
-                      f"{os.path.join(skill_dir, entry.uuid)}")
-            if entry.download(skill_dir):
-                LOG.info(f"Downloaded failed skill: {entry.uuid}")
-            else:
-                LOG.error(f"Failed to download: {entry.uuid}")
-        else:
-            LOG.info(f"Installed {skill_url} to {skill_dir}")
-    except Exception as e:
-        LOG.exception(e)
-
-
 def _install_skill_pip(skill_package: str, constraints_file: str) -> bool:
     """
     Pip install the specified package
@@ -159,20 +117,12 @@ def _install_skill_pip(skill_package: str, constraints_file: str) -> bool:
 
 def install_skills_from_list(skills_to_install: list, config: dict = None):
     """
-    Installs the passed list of skill URLs and/or PyPI package names
+    Installs the passed list of skills (valid pip arguments).
     :param skills_to_install: list of skills to install
     :param config: optional dict configuration
     """
     config = config or Configuration()["skills"]
-    LOG.info(f"extra_directories={config.get('extra_directories')}")
-    LOG.info(f"directory={config.get('directory')}")
-    skill_dir = expanduser(config.get("extra_directories")[0] if
-                           config.get("extra_directories") else
-                           config.get("directory") if config.get("directory")
-                           and config["directory"] != "skills" else
-                           join(xdg_data_home(), "neon", "skills"))
-    LOG.info(f"skill_dir={skill_dir}")
-    skills_catalog = None
+
     token_set = False
     if config.get("neon_token"):
         LOG.warning("Authenticated installation from git is deprecated. "
@@ -182,30 +132,19 @@ def install_skills_from_list(skills_to_install: list, config: dict = None):
         set_github_token(config["neon_token"])
         LOG.info(f"Added token to request headers: {config.get('neon_token')}")
 
-    constraints_file = '/etc/mycroft/constraints.txt'
-    try:
-        _write_pip_constraints_to_file(constraints_file)
-    except PermissionError:
-        LOG.warning(f"Unable to write pip constraints file {constraints_file}")
-        from ovos_skills_manager.utils import set_osm_constraints_file
-        constraints_file = join(xdg_data_home(), "neon", "constraints.txt")
-        _write_pip_constraints_to_file(constraints_file)
-        set_osm_constraints_file(constraints_file)
+    constraints_file = join(xdg_data_home(), "neon", "constraints.txt")
+    _write_pip_constraints_to_file(constraints_file)
 
-    for url in skills_to_install:
-        if "://" in url and "git+" not in url:
-            skills_catalog = skills_catalog or get_neon_skills_data()
-            _install_skill_osm(url, skill_dir, skills_catalog)
-        else:
-            if not _install_skill_pip(url, constraints_file):
-                LOG.warning(f"Pip installation failed for: {url}")
-                skills_catalog = skills_catalog or get_neon_skills_data()
-                _install_skill_osm(url, skill_dir, skills_catalog)
+    for spec in skills_to_install:
+        if "://" in spec and "git+" not in spec:
+            LOG.error(f"Got an invalid package spec to install: {spec}")
+        elif not _install_skill_pip(spec, constraints_file):
+            LOG.error(f"Pip installation failed for: {spec}")
 
     if token_set:
         from ovos_skills_manager.session import clear_github_token
         clear_github_token()
-    LOG.info(f"Installed {len(skills_to_install)} skills to: {skill_dir}")
+    LOG.info(f"Installed {len(skills_to_install)} skills")
 
 
 def install_skills_default(config: dict = None):

--- a/neon_core/util/skill_utils.py
+++ b/neon_core/util/skill_utils.py
@@ -75,11 +75,14 @@ def get_neon_skills_data(skill_meta_repository: str =
     return skills_data
 
 
-def _write_pip_constraints_to_file(output_file):
+def _write_pip_constraints_to_file(output_file: str):
     """
     Writes out a constraints file for OSM to use to prevent broken dependencies
     :param output_file: path to constraints file to write
     """
+    if not output_file:
+        raise ValueError(f"Expected string path but got: {output_file}")
+
     from neon_utils.packaging_utils import get_package_dependencies
     if not isdir(dirname(output_file)):
         makedirs(dirname(output_file))

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -113,8 +113,8 @@ class SkillUtilsTests(unittest.TestCase):
         install_skills_from_list(TEST_SKILLS_WITH_PIP, SKILL_CONFIG)
         skill_dirs = [d for d in os.listdir(SKILL_DIR)
                       if os.path.isdir(os.path.join(SKILL_DIR, d))]
-        self.assertEqual(len(skill_dirs), 1)
-        self.assertIn("skill-date_time.neongeckocom", skill_dirs)
+        self.assertEqual(len(skill_dirs), 0)
+        # self.assertIn("skill-date_time.neongeckocom", skill_dirs)
 
         returned = os.system("pip show neon-skill-support-helper")
         self.assertEqual(returned, 0)

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -133,6 +133,10 @@ class SkillUtilsTests(unittest.TestCase):
     def test_write_pip_constraints_to_file(self):
         from neon_core.util.skill_utils import _write_pip_constraints_to_file
         from neon_utils.packaging_utils import get_package_dependencies
+
+        with self.assertRaises(ValueError):
+            _write_pip_constraints_to_file("")
+
         real_deps = get_package_dependencies("neon-core")
         real_deps = [f'{c.split("[")[0]}{c.split("]")[1]}' if '[' in c
                      else c for c in real_deps if '@' not in c]

--- a/test/test_skill_utils.py
+++ b/test/test_skill_utils.py
@@ -73,11 +73,9 @@ class SkillUtilsTests(unittest.TestCase):
 
     def test_get_skills_from_remote_list(self):
         from neon_core.util.skill_utils import _get_skills_from_remote_list
-        # from ovos_skills_manager.session import set_github_token,\
-        #     clear_github_token
-        # set_github_token(SKILL_CONFIG["neon_token"])
+
         skills_list = _get_skills_from_remote_list(SKILL_CONFIG["default_skills"])
-        # clear_github_token()
+
         self.assertIsInstance(skills_list, list)
         self.assertTrue(len(skills_list) > 0)
         self.assertTrue(all(skill.startswith("https://github.com")
@@ -109,13 +107,6 @@ class SkillUtilsTests(unittest.TestCase):
         expected = _get_skills_from_remote_list(SKILL_CONFIG["default_skills"])
         install_skills.assert_called_once_with(expected,
                                                install_skills.call_args[0][1])
-        # skill_dirs = [d for d in os.listdir(SKILL_DIR) if
-        #               os.path.isdir(os.path.join(SKILL_DIR, d))]
-        # self.assertEqual(
-        #     len(skill_dirs),
-        #     len(_get_skills_from_remote_list(SKILL_CONFIG["default_skills"])),
-        #     f"{skill_dirs}\n\n"
-        #     f"{_get_skills_from_remote_list(SKILL_CONFIG['default_skills'])}")
 
     def test_install_skills_with_pip(self):
         from neon_core.util.skill_utils import install_skills_from_list
@@ -128,6 +119,7 @@ class SkillUtilsTests(unittest.TestCase):
         returned = os.system("pip show neon-skill-support-helper")
         self.assertEqual(returned, 0)
 
+    @skip("OSM skill installation deprecated")
     def test_get_neon_skills_data(self):
         from neon_core.util.skill_utils import get_neon_skills_data
         from ovos_skills_manager.github.utils import normalize_github_url
@@ -137,27 +129,6 @@ class SkillUtilsTests(unittest.TestCase):
             self.assertIsInstance(neon_skills[skill], dict)
             self.assertEqual(skill,
                              normalize_github_url(neon_skills[skill]["url"]))
-
-    # @skip("Local skill installation deprecated")
-    # def test_install_local_skills(self):
-    #     import ovos_skills_manager.requirements
-    #     import neon_core.util.skill_utils
-    #     importlib.reload(neon_core.util.skill_utils)
-    #     install_pip_deps = Mock()
-    #     install_sys_deps = Mock()
-    #     ovos_skills_manager.requirements.pip_install = install_pip_deps
-    #     ovos_skills_manager.requirements.install_system_deps = install_sys_deps
-    #
-    #     install_local_skills = neon_core.util.skill_utils.install_local_skills
-    #
-    #     local_skills_dir = os.path.join(os.path.dirname(__file__),
-    #                                     "local_skills")
-    #
-    #     installed = install_local_skills(local_skills_dir)
-    #     num_installed = len(installed)
-    #     self.assertEqual(installed, os.listdir(local_skills_dir))
-    #     self.assertEqual(num_installed, install_pip_deps.call_count)
-    #     self.assertEqual(num_installed, install_sys_deps.call_count)
 
     def test_write_pip_constraints_to_file(self):
         from neon_core.util.skill_utils import _write_pip_constraints_to_file
@@ -172,14 +143,6 @@ class SkillUtilsTests(unittest.TestCase):
             read_deps = f.read().split('\n')
         self.assertTrue(all((d in read_deps for d in real_deps)))
 
-        try:
-            _write_pip_constraints_to_file()
-            self.assertTrue(os.path.isfile("/etc/mycroft/constraints.txt"))
-            with open("/etc/mycroft/constraints.txt") as f:
-                deps = f.read().split('\n')
-            self.assertTrue(all((d in deps for d in real_deps)))
-        except Exception as e:
-            self.assertIsInstance(e, PermissionError)
         os.remove(test_outfile)
 
     # def test_set_osm_constraints_file(self):


### PR DESCRIPTION
# Description
Deprecate OSM installation helpers in `skill_utils` and tests
Deprecates `neon_token` config handling

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->