### PR TITLE
Move audio-receiver dependencies into extras

### DIFF
--- a/requirements/audio_receiver.txt
+++ b/requirements/audio_receiver.txt
@@ -1,3 +1,3 @@
 skill-markII-audio-receiver~=0.1
 PyBluez~=0.23
-PyGObject~=3.44
+PyGObject~=3.44.1

--- a/requirements/audio_receiver.txt
+++ b/requirements/audio_receiver.txt
@@ -1,0 +1,3 @@
+skill-markII-audio-receiver~=0.1
+PyBluez~=0.23
+PyGObject~=3.44

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -60,7 +60,6 @@ ovos-skill-homescreen~=0.0.3
 
 # ovos-skill-setup~=0.0.1
 ovos-skill-volume~=0.0.2
-skill-markII-audio-receiver~=0.1
 
 # Used for Demo Skill
 ovos-tts-plugin-mimic~=0.3

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -61,5 +61,8 @@ ovos-skill-homescreen~=0.0.3
 # ovos-skill-setup~=0.0.1
 ovos-skill-volume~=0.0.2
 
+# Included in `audio-receiver` extras, but here for Mark II backwards-compat
+skill-markII-audio-receiver~=0.1
+
 # Used for Demo Skill
 ovos-tts-plugin-mimic~=0.3

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "skills-essential": get_requirements("skills_essential.txt"),
         "skills-default": get_requirements("skills_default.txt"),
         "skills-extended": get_requirements("skills_extended.txt"),
-        "audio-receiver": get_requirements("audio_receiver")
+        "audio-receiver": get_requirements("audio_receiver.txt")
     },
     packages=find_packages(include=['neon_core*']),
     package_data={'neon_core': ['res/precise_models/*', 'res/snd/*',

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         "skills-essential": get_requirements("skills_essential.txt"),
         "skills-default": get_requirements("skills_default.txt"),
         "skills-extended": get_requirements("skills_extended.txt"),
+        "audio-receiver": get_requirements("audio_receiver")
     },
     packages=find_packages(include=['neon_core*']),
     package_data={'neon_core': ['res/precise_models/*', 'res/snd/*',

--- a/test/pi_setup_3_10.sh
+++ b/test/pi_setup_3_10.sh
@@ -33,17 +33,13 @@ echo "nameserver 1.1.1.1" | tee /etc/resolv.conf
 
 # install system packages
 apt update
-apt install -y curl apt-utils
+apt install -y curl
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
 apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make || exit 1
 # Audio Receiver dependencies
 apt install -y libcairo2-dev libgirepository1.0-dev bluez* libbluetooth-dev pulseaudio-module-bluetooth 
-
-# TODO: For troubleshooting GHA failure
-find /usr/lib /usr/lib/aarch64-linux-gnu -name girepository-2.0.pc || echo "girepository-2.0.pc not found"
-
 
 cd /core || exit 10
 python3.10 -m venv "/core/venv" || exit 11

--- a/test/pi_setup_3_10.sh
+++ b/test/pi_setup_3_10.sh
@@ -37,7 +37,7 @@ apt install -y curl
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
-apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make libcairo2-dev || exit 1
+apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make libcairo2-dev libgirepository1.0-dev || exit 1
 
 cd /core || exit 10
 python3.10 -m venv "/core/venv" || exit 11

--- a/test/pi_setup_3_10.sh
+++ b/test/pi_setup_3_10.sh
@@ -37,7 +37,7 @@ apt install -y curl
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
-apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make libcairo2-dev libgirepository2.0-dev || exit 1
+apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make libcairo2-dev libgirepository1.0-dev || exit 1
 
 cd /core || exit 10
 python3.10 -m venv "/core/venv" || exit 11

--- a/test/pi_setup_3_10.sh
+++ b/test/pi_setup_3_10.sh
@@ -33,12 +33,17 @@ echo "nameserver 1.1.1.1" | tee /etc/resolv.conf
 
 # install system packages
 apt update
-apt install -y curl
+apt install -y curl apt-utils
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
-apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make libcairo2-dev libgirepository1.0-dev || exit 1
-find /usr/lib /usr/lib/aarch64-linux-gnu -name girepository-2.0.pc
+apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make || exit 1
+# Audio Receiver dependencies
+apt install -y libcairo2-dev libgirepository1.0-dev bluez* libbluetooth-dev pulseaudio-module-bluetooth 
+
+# TODO: For troubleshooting GHA failure
+find /usr/lib /usr/lib/aarch64-linux-gnu -name girepository-2.0.pc || echo "girepository-2.0.pc not found"
+
 
 cd /core || exit 10
 python3.10 -m venv "/core/venv" || exit 11

--- a/test/pi_setup_3_10.sh
+++ b/test/pi_setup_3_10.sh
@@ -37,7 +37,7 @@ apt install -y curl
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
-apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make || exit 1
+apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make libcairo2-dev || exit 1
 
 cd /core || exit 10
 python3.10 -m venv "/core/venv" || exit 11

--- a/test/pi_setup_3_10.sh
+++ b/test/pi_setup_3_10.sh
@@ -37,7 +37,7 @@ apt install -y curl
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
-apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make libcairo2-dev libgirepository1.0-dev || exit 1
+apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make libcairo2-dev libgirepository2.0-dev || exit 1
 
 cd /core || exit 10
 python3.10 -m venv "/core/venv" || exit 11

--- a/test/pi_setup_3_10.sh
+++ b/test/pi_setup_3_10.sh
@@ -44,6 +44,6 @@ python3.10 -m venv "/core/venv" || exit 11
 . /core/venv/bin/activate
 
 pip install --upgrade pip wheel
-pip install ".[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi]" || exit 11
+pip install ".[core-modules,skills-required,skills-essential,skills-default,skills-extended,pi,audio-receiver]" || exit 11
 
 cp -rf /core/test/pi_image_overlay/* /

--- a/test/pi_setup_3_10.sh
+++ b/test/pi_setup_3_10.sh
@@ -38,6 +38,7 @@ curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | a
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
 apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make libcairo2-dev libgirepository1.0-dev || exit 1
+find /usr/lib /usr/lib/aarch64-linux-gnu -name girepository-2.0.pc
 
 cd /core || exit 10
 python3.10 -m venv "/core/venv" || exit 11

--- a/test/pi_setup_3_11.sh
+++ b/test/pi_setup_3_11.sh
@@ -37,7 +37,7 @@ apt install -y curl
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
-apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make python3.11-dev python3.11-venv libcairo2-dev libgirepository2.0-dev || exit 1
+apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make python3.11-dev python3.11-venv libcairo2-dev libgirepository1.0-dev || exit 1
 
 cd /core || exit 10
 python3.11 -m venv "/core/venv" || exit 11

--- a/test/pi_setup_3_11.sh
+++ b/test/pi_setup_3_11.sh
@@ -37,7 +37,7 @@ apt install -y curl
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
-apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make python3.11-dev python3.11-venv libcairo2-dev libgirepository1.0-dev || exit 1
+apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make python3.11-dev python3.11-venv libcairo2-dev libgirepository2.0-dev || exit 1
 
 cd /core || exit 10
 python3.11 -m venv "/core/venv" || exit 11

--- a/test/pi_setup_3_11.sh
+++ b/test/pi_setup_3_11.sh
@@ -37,7 +37,7 @@ apt install -y curl
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
-apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make python3.11-dev python3.11-venv || exit 1
+apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make python3.11-dev python3.11-venv libcairo2-dev || exit 1
 
 cd /core || exit 10
 python3.11 -m venv "/core/venv" || exit 11

--- a/test/pi_setup_3_11.sh
+++ b/test/pi_setup_3_11.sh
@@ -37,7 +37,7 @@ apt install -y curl
 curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.key | apt-key add - 2> /dev/null && \
 echo "deb http://forslund.github.io/mycroft-desktop-repo bionic main" | tee /etc/apt/sources.list.d/mycroft-desktop.list
 apt update
-apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make python3.11-dev python3.11-venv libcairo2-dev || exit 1
+apt install -y sox gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev mimic espeak-ng g++ libjpeg-dev make python3.11-dev python3.11-venv libcairo2-dev libgirepository1.0-dev || exit 1
 
 cd /core || exit 10
 python3.11 -m venv "/core/venv" || exit 11
@@ -46,6 +46,6 @@ python3.11 -m venv "/core/venv" || exit 11
 pip install --upgrade pip wheel
 pip install https://github.com/smartgic/python-tflite-runtime/releases/download/2.13.0-cp311/tflite_runtime-2.13.0-cp311-cp311-linux_aarch64.whl
 #pip install https://whl.smartgic.io/tflite_runtime-2.13.0-cp311-cp311-linux_aarch64.whl
-pip install ".[core-modules,skills-required,skills-essential,skills-default,skills-extended,pi,audio-receiver]" || exit 11
+pip install ".[core-modules,skills-required,skills-essential,skills-default,skills-extended,pi]" || exit 11
 
 cp -rf /core/test/pi_image_overlay/* /

--- a/test/pi_setup_3_11.sh
+++ b/test/pi_setup_3_11.sh
@@ -46,6 +46,6 @@ python3.11 -m venv "/core/venv" || exit 11
 pip install --upgrade pip wheel
 pip install https://github.com/smartgic/python-tflite-runtime/releases/download/2.13.0-cp311/tflite_runtime-2.13.0-cp311-cp311-linux_aarch64.whl
 #pip install https://whl.smartgic.io/tflite_runtime-2.13.0-cp311-cp311-linux_aarch64.whl
-pip install ".[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi]" || exit 11
+pip install ".[core-modules,skills-required,skills-essential,skills-default,skills-extended,pi,audio-receiver]" || exit 11
 
 cp -rf /core/test/pi_image_overlay/* /


### PR DESCRIPTION
# Description
Add audio receiver dependencies to extras (currently manually handled in debos recipe)

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- This needs a companion PR in `neon_debos` to install from these extras, rather than bundled wheels
- PyBluez also is not supported, starting in Python 3.10.x and is no longer maintained. In the future, we will want to move away from that dependency for Bluetooth casting