### PR TITLE
Update required skills to stable versions

### DIFF
--- a/requirements/skills_required.txt
+++ b/requirements/skills_required.txt
@@ -1,3 +1,4 @@
-ovos-skill-stop~=0.2,>=0.3.0a7
-neon-skill-fallback_unknown~=1.2,>=1.2.1a1
+# TODO: Stop skill deprecated with ovos-core 0.0.8; pinned last release (with stable dependencies)
+ovos-skill-stop==0.3.0a9
+neon-skill-fallback_unknown~=2.0
 neon-skill-communication~=0.1


### PR DESCRIPTION
# Description
Updates fallback-unknown skill to stable release
Pins stop skill to last release with stable dependencies

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
The stop skill will be deprecated with the ovos-core 0.0.8 refactor (#411)