### PR TITLE
Remove ovos-utils deprecated references

### DIFF
--- a/neon_core/skills/patched_common_query.py
+++ b/neon_core/skills/patched_common_query.py
@@ -35,7 +35,7 @@ from typing import Dict
 from ovos_bus_client.session import SessionManager
 from ovos_bus_client.message import Message, dig_for_message
 from ovos_utils import flatten_list
-from ovos_utils.enclosure.api import EnclosureAPI
+from ovos_bus_client.apis.enclosure import EnclosureAPI
 from ovos_utils.log import LOG
 from ovos_utils.messagebus import get_message_lang
 

--- a/neon_core/skills/service.py
+++ b/neon_core/skills/service.py
@@ -35,7 +35,7 @@ from ovos_bus_client import Message, MessageBusClient
 from ovos_config.locale import set_default_lang, set_default_tz
 from ovos_config.config import Configuration
 from ovos_utils.log import LOG
-from ovos_utils.skills.locations import get_plugin_skills, get_skill_directories
+from ovos_plugin_manager.skills import get_plugin_skills, get_skill_directories
 from ovos_utils.process_utils import StatusCallbackMap
 from neon_utils.metrics_utils import announce_connection
 from neon_utils.signal_utils import init_signal_handlers, init_signal_bus

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ ovos-core==0.0.7
 # padacioso==0.1.3a2
 
 neon-utils[network]~=1.10
-ovos-utils~=0.0.38
+ovos-utils~=0.0,>=0.0.38
 ovos-bus-client~=0.0.8
 neon-transformers~=0.2
 ovos-config~=0.0.12

--- a/test/test_skills_module.py
+++ b/test/test_skills_module.py
@@ -131,8 +131,8 @@ class TestSkillService(unittest.TestCase):
         stopping_hook.assert_called_once()
         service.join(10)
 
-    @patch("ovos_utils.skills.locations.get_plugin_skills")
-    @patch("ovos_utils.skills.locations.get_skill_directories")
+    @patch("ovos_plugin_manager.skills.get_plugin_skills")
+    @patch("ovos_plugin_manager.skills.get_skill_directories")
     def test_get_skill_dirs(self, skill_dirs, plugin_skills):
         from neon_core.skills.service import NeonSkillService
 


### PR DESCRIPTION
# Description
Update ovos-utils references for 0.1 compat
Update ovos-utils dependency spec to allow 0.1

# Issues
Relates to https://github.com/NeonGeckoCom/NeonCore/pull/641

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->