### PR TITLE
feat: Home Assistant skill config

### DIFF
--- a/neon_core/configuration/mark_2/skills/neon_homeassistant_skill.mikejgray/settings.json
+++ b/neon_core/configuration/mark_2/skills/neon_homeassistant_skill.mikejgray/settings.json
@@ -1,0 +1,4 @@
+{
+  "__mycroft_skill_firstrun": false,
+  "disable_intents": true
+}

--- a/requirements/skills_extended.txt
+++ b/requirements/skills_extended.txt
@@ -8,5 +8,5 @@ neon-skill-synonyms~=1.0,>=1.0.2
 neon-skill-translation~=1.0,>=1.0.1
 neon-skill-camera~=1.0,>=1.0.1
 ovos-skill-somafm~=0.0.1
-neon-homeassistant-skill~=0.0.14
+neon-homeassistant-skill~=0.0.18
 ovos-skill-icanhazdadjokes @ git+https://github.com/openvoiceos/skill-ovos-icanhazdadjokes@882f4bd1bab077a531b9f6979510b78f340a1886


### PR DESCRIPTION
# Description
Starting with neon-homeassistant-skill 0.0.17 this configuration is what is required to load the skill with standard intents disabled. There are intents available to re-enable them or the user can edit the settings.json file manually.

# Issues
Closes #625

# Other Notes
Requires this PR to merge (neon-homeassistant-skill 0.0.17) https://github.com/mikejgray/neon-homeassistant-skill/pull/41