### PR TITLE
Update configuration to use HANA public IP endpoint

### DIFF
--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -205,6 +205,8 @@ gui_websocket:
   route: /gui
   ssl: false
 network_tests:
+  # TODO: Update to neonaiservices.com
+  ip_url: https://hana.neonaibeta.com/util/client_ip
   dns_primary: 1.1.1.1
   dns_secondary: 1.0.0.1
   web_url: https://www.google.com

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -47,7 +47,7 @@ ovos-phal-plugin-system~=0.0,>=0.0.5a1
 ovos-phal-plugin-connectivity-events~=0.0.3
 ovos-phal-plugin-homeassistant~=0.0.3,>=0.0.4a5
 ovos-phal-plugin-wallpaper-manager~=0.0.1
-ovos-phal-plugin-ipgeo~=0.0.2
+ovos-phal-plugin-ipgeo~=0.0.2,>=0.0.3a2
 ovos-phal-plugin-mk1 @ git+https://github.com/openvoiceos/ovos-phal-plugin-mk1@dev
 # TODO: Stable spec for mk1 plugin
 # ovos-phal-plugin-gpsd @ git+https://github.com/OpenVoiceOS/ovos-PHAL-plugin-gpsd


### PR DESCRIPTION
# Description
Explicitly sets URL to get public IP to a Neon-managed service

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Feature implemented https://github.com/NeonGeckoCom/neon-hana/pull/26
Issue originally reported in the [OpenConversational.AI Forums](https://community.openconversational.ai/t/trying-neon-ovos-again/14904/2)