### PR TITLE
Resolve shutdown/restart bug

### DIFF
--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -43,7 +43,7 @@ ovos-phal-plugin-network-manager~=1.1
 ovos-phal-plugin-wifi-setup~=1.0,>=1.1.2a1
 ovos-phal-plugin-oauth~=0.0,>=0.0.3a3
 ovos-phal-plugin-alsa~=0.0.3
-ovos-phal-plugin-system~=0.0,>=0.0.5a1
+ovos-phal-plugin-system~=0.0,>=0.0.5a1,!=0.0.5a2
 ovos-phal-plugin-connectivity-events~=0.0.3
 ovos-phal-plugin-homeassistant~=0.0.3,>=0.0.4a5
 ovos-phal-plugin-wallpaper-manager~=0.0.1


### PR DESCRIPTION
# Description
Exclude system plugin version with incorrect dependency spec

# Issues
Closes #673

# Other Notes
This should resolve ovos-PHAL-plugin-system==0.0.5a1