### PR TITLE
Update neon-enclosure and ovos-bus-client to resolve issues

### DIFF
--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,6 +1,6 @@
 # neon core modules
 neon-messagebus~=2.0,>=2.0.2a6
-neon-enclosure~=1.7,>=1.7.1a1
+neon-enclosure~=1.7,>=1.7.1a2
 neon-speech~=4.4,>=4.4.1
 neon-gui~=1.3,>=1.3.1a1
 neon-audio~=1.5,>=1.5.2a6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ ovos-core[mycroft,lgpl]>=0.0.8a95
 neon-utils[network,audio]~=1.10,>=1.10.2a8
 # TODO: audio for alpha resolution
 ovos-utils~=0.0,>=0.0.38
-ovos-bus-client~=0.0.8,>=0.0.9a20
+ovos-bus-client~=0.0.8,>=0.0.9a25
 neon-transformers~=0.2,>=0.2.1a4
 ovos-config~=0.0.12
 ovos-plugin-manager~=0.0.25,>=0.0.26a19


### PR DESCRIPTION
# Description
Update neon-enclosure to add support for disabled plugins (https://github.com/NeonGeckoCom/neon_enclosure/pull/93)
Updates ovos-bus-client to reduce exceptions

# Issues
Mitigates issues noted in #687
Closes #686

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->