### PR TITLE
Truncate Mark2 Logs

### DIFF
--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -161,6 +161,11 @@ logs:
       - botocore
     info: []
     debug: []
+logging:
+  # 2M max size per log file to keep within  the 10M log limit
+  max_bytes: 2097152
+  # Backups count towards the cache limit too; skip any backups
+  backup_count: 0
 debug: False
 system_unit: imperial
 system:

--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -151,8 +151,9 @@ log_dir: /home/neon/logs/
 log_level: INFO
 logs:
   path: /home/neon/.local/state/neon/
-  max_bytes: 50000000
-  backup_count: 3
+  # 2M max size per log file to keep within the 10M log limit
+  max_bytes: 1048576
+  backup_count: 1
   diagnostic: False
   level_overrides:
     error: []
@@ -161,11 +162,6 @@ logs:
       - botocore
     info: []
     debug: []
-logging:
-  # 2M max size per log file to keep within  the 10M log limit
-  max_bytes: 2097152
-  # Backups count towards the cache limit too; skip any backups
-  backup_count: 0
 debug: False
 system_unit: imperial
 system:


### PR DESCRIPTION
# Description
Updates mark2 configuration to limit logs to 1M size with 1 backup (2M/log max)

# Issues
Relates to https://github.com/NeonGeckoCom/neon_debos/issues/145

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->