### PR TITLE
Update logging config handling and default configurations

### DIFF
--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -148,20 +148,21 @@ server:
 
 # Logging Config
 log_dir: /home/neon/logs/
-log_level: INFO
-logs:
-  path: /home/neon/.local/state/neon/
-  # 2M max size per log file to keep within the 10M log limit
-  max_bytes: 1048576
-  backup_count: 1
-  diagnostic: False
-  level_overrides:
-    error: []
-    warning:
-      - filelock
-      - botocore
-    info: []
-    debug: []
+logging:
+  log_level: INFO
+  logs:
+    path: /home/neon/.local/state/neon/
+    # 2M max size per log file to keep within the 10M log limit
+    max_bytes: 1048576
+    backup_count: 1
+    diagnostic: False
+  bus:
+    log_level: INFO
+    path: /home/neon/.local/state/neon/
+    # 2M max size per log file to keep within the 10M log limit
+    max_bytes: 1048576
+    backup_count: 1
+    diagnostic: False
 debug: False
 system_unit: imperial
 system:

--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -232,12 +232,13 @@ signal:
   max_wait_seconds: 300
 
 # Logging Config
-log_level: INFO
-logs:
-  path:
-  max_bytes: 50000000
-  backup_count: 3
-  diagnostic: False
+logging:
+  log_level: INFO
+  logs:
+    path:
+    max_bytes: 50000000
+    backup_count: 3
+    diagnostic: False
   level_overrides:
     error: []
     warning:

--- a/neon_core/configuration/opi5/neon.yaml
+++ b/neon_core/configuration/opi5/neon.yaml
@@ -130,19 +130,21 @@ server:
 
 # Logging Config
 log_dir: /home/neon/logs/
-log_level: INFO
-logs:
-  path: /home/neon/.local/state/neon/
-  max_bytes: 50000000
-  backup_count: 3
-  diagnostic: False
-  level_overrides:
-    error: []
-    warning:
-      - filelock
-      - botocore
-    info: []
-    debug: []
+logging:
+  log_level: INFO
+  logs:
+    path: /home/neon/.local/state/neon/
+    # 2M max size per log file to keep within the 10M log limit
+    max_bytes: 1048576
+    backup_count: 1
+    diagnostic: False
+  bus:
+    log_level: INFO
+    path: /home/neon/.local/state/neon/
+    # 2M max size per log file to keep within the 10M log limit
+    max_bytes: 1048576
+    backup_count: 1
+    diagnostic: False
 debug: False
 system_unit: imperial
 system:

--- a/neon_core/configuration/rpi4/neon.yaml
+++ b/neon_core/configuration/rpi4/neon.yaml
@@ -131,19 +131,21 @@ server:
 
 # Logging Config
 log_dir: /home/neon/logs/
-log_level: INFO
-logs:
-  path: /home/neon/.local/state/neon/
-  max_bytes: 50000000
-  backup_count: 3
-  diagnostic: False
-  level_overrides:
-    error: []
-    warning:
-      - filelock
-      - botocore
-    info: []
-    debug: []
+logging:
+  log_level: INFO
+  logs:
+    path: /home/neon/.local/state/neon/
+    # 2M max size per log file to keep within the 10M log limit
+    max_bytes: 1048576
+    backup_count: 1
+    diagnostic: False
+  bus:
+    log_level: INFO
+    path: /home/neon/.local/state/neon/
+    # 2M max size per log file to keep within the 10M log limit
+    max_bytes: 1048576
+    backup_count: 1
+    diagnostic: False
 debug: False
 system_unit: imperial
 system:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,8 @@
 ovos-core[mycroft,lgpl]>=0.0.8a95
 # padacioso==0.1.3a2
 
-neon-utils[network]~=1.11
+neon-utils[network,audio]~=1.11,>=1.11.1a1
+# TODO: `audio` extra for dependency resolution
 ovos-utils~=0.0,>=0.0.38
 ovos-bus-client~=0.0.8,>=0.0.9a25
 neon-transformers~=0.2,>=0.2.1a4


### PR DESCRIPTION
# Description
Update neon-utils dependency to include updated log config handling
Update logging configuration to use new `logging` section
Update device configurations to override `bus` log level to `INFO` to prevent logs exceeding 2M in the first few minutes of startup

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->