### PR TITLE
Update neon-audio to resolve playback errors

### DIFF
--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -1,3 +1,6 @@
+# TODO: Below adding intermediate support for ovos-audio 0.x
+enable_old_audioservice: True
+
 # Plugin Configuration
 utterance_transformers:
   neon_utterance_translator_plugin:

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -5,3 +5,4 @@ neon-speech~=4.4,>=4.4.1
 neon-gui~=1.3,>=1.3.1a1
 #neon-audio~=1.5.1
 neon-audio@git+https://github.com/neongeckocom/neon_audio@FIX_NoPlayback
+ovos-audio<=0.2.0

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -3,5 +3,8 @@ neon-messagebus~=2.0,>=2.0.2a6
 neon-enclosure~=1.7,>=1.7.1a2
 neon-speech~=4.4,>=4.4.1
 neon-gui~=1.3,>=1.3.1a1
+
+# TODO: Patching breaking change in ovos-audio/OPM
 neon-audio==1.5.2a6
 ovos-audio==0.0.2a42
+ovos-plugin-manager==0.0.26a19

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -3,6 +3,4 @@ neon-messagebus~=2.0,>=2.0.2a6
 neon-enclosure~=1.7,>=1.7.1a2
 neon-speech~=4.4,>=4.4.1
 neon-gui~=1.3,>=1.3.1a1
-#neon-audio~=1.5.1
-neon-audio@git+https://github.com/neongeckocom/neon_audio@FIX_NoPlayback
-ovos-audio<=0.2.0
+neon-audio~=1.5.1,>=1.5.2a10

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -3,8 +3,4 @@ neon-messagebus~=2.0,>=2.0.2a6
 neon-enclosure~=1.7,>=1.7.1a2
 neon-speech~=4.4,>=4.4.1
 neon-gui~=1.3,>=1.3.1a1
-
-# TODO: Patching breaking change in ovos-audio/OPM
-neon-audio==1.5.2a6
-ovos-audio==0.0.2a42
-ovos-plugin-manager==0.0.26a19
+neon-audio~=1.5.1

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -3,4 +3,5 @@ neon-messagebus~=2.0,>=2.0.2a6
 neon-enclosure~=1.7,>=1.7.1a2
 neon-speech~=4.4,>=4.4.1
 neon-gui~=1.3,>=1.3.1a1
-neon-audio~=1.5.1
+#neon-audio~=1.5.1
+neon-audio@git+https://github.com/neongeckocom/neon_audio@FIX_NoPlayback

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 # ovos-core version pinned for compat. with patches in NeonCore
-ovos-core[mycroft,lgpl]>=0.0.8a95
+ovos-core[mycroft,lgpl]>=0.0.8a95,<=0.0.8a100
 # padacioso==0.1.3a2
 
 neon-utils[network,audio]~=1.11,>=1.11.1a3
@@ -8,7 +8,7 @@ ovos-utils~=0.0,>=0.0.38
 ovos-bus-client~=0.0.8,>=0.0.9a25
 neon-transformers~=0.2,>=0.2.1a4
 ovos-config~=0.0.12,>=0.0.13a27
-ovos-plugin-manager==0.0.26a20
+ovos-plugin-manager~=0.0.25,>=0.0.26a19
 # TODO: ovos-backend-client pinned for stable release
 ovos-backend-client==0.1.1a5
 psutil~=5.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,7 +8,7 @@ ovos-utils~=0.0,>=0.0.38
 ovos-bus-client~=0.0.8,>=0.0.9a25
 neon-transformers~=0.2,>=0.2.1a4
 ovos-config~=0.0.12,>=0.0.13a27
-ovos-plugin-manager~=0.0.25,>=0.0.26a19
+ovos-plugin-manager==0.0.26a20
 # TODO: ovos-backend-client pinned for stable release
 ovos-backend-client==0.1.1a5
 psutil~=5.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 # ovos-core version pinned for compat. with patches in NeonCore
-ovos-core[mycroft,lgpl]>=0.0.8a95,<=0.0.8a100
+ovos-core[mycroft,lgpl]>=0.0.8a95,<=0.0.8a99
 # padacioso==0.1.3a2
 
 neon-utils[network,audio]~=1.11,>=1.11.1a3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 # ovos-core version pinned for compat. with patches in NeonCore
-ovos-core[mycroft,lgpl]>=0.0.8a95,<=0.0.8a99
+ovos-core[mycroft,lgpl]>=0.0.8a95,<=0.0.8a100
 # padacioso==0.1.3a2
 
 neon-utils[network,audio]~=1.11,>=1.11.1a3


### PR DESCRIPTION
# Description
Updates neon-audio dependency to a version that includes backwards-compat. working audio playback
Updates default config to use the legacy audio service

# Issues
https://github.com/NeonGeckoCom/neon_audio/pull/177

# Other Notes
Audio will be updated again to use the new audio service, but only after skills have been updated for compat. with 0.x OVOS dependencies and tested against this release