### PR TITLE
Update Neon dependencies to support OVOS 0.x packages

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,3 @@
-neon-cli-client~=0.2
-neon-mana-utils~=0.2,>=0.2.3a2
+neon-cli-client~=0.2,>=0.3.1a1
+neon-mana-utils~=0.3
 neon-minerva~=0.1

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,5 +1,5 @@
 # TTS Plugin configured for Demo Skill
-ovos-tts-plugin-mimic
+ovos-tts-plugin-mimic~=0.2
 
 # "Lite" homescreen disables edge-device functionality
 ovos-skill-homescreen-lite @ git+https://github.com/openvoiceos/skill-homescreen-lite

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -7,7 +7,7 @@ pydbus~=0.6
 sdnotify~=0.3
 
 # Default debug client
-neon-cli-client~=0.3
+neon-cli-client~=0.3,>=0.3.1a1
 neon-mana-utils~=0.2,>=0.2.3a2
 
 # Default plugins
@@ -17,23 +17,23 @@ ovos-ww-plugin-precise~=0.1
 ovos-ww-plugin-precise-lite[tflite]~=0.1,>=0.1.2
 ovos-ww-plugin-vosk~=0.1,>=0.1.1
 ovos-ww-plugin-openwakeword~=0.2
-neon-stt-plugin-google-cloud-streaming~=1.0,>=1.0.1
+neon-stt-plugin-google-cloud-streaming~=1.0,>=1.0.2a3
 
-neon-tts-plugin-coqui-remote~=0.0.3
-neon-stt-plugin-nemo~=0.0.4,>=0.0.5a2
+neon-tts-plugin-coqui-remote~=0.0.3,>=0.0.4a2
+neon-stt-plugin-nemo~=0.0.4,>=0.0.5a4
 ovos-tts-plugin-server==0.0.2a12
 ovos-stt-plugin-server~=0.0.3
 ovos-tts-plugin-piper~=0.0.1a11
 
 # Fallback plugins
-neon-tts-plugin-coqui~=0.8,>=0.8.1a2
+neon-tts-plugin-coqui~=0.8,>=0.8.1a3
 ovos-stt-plugin-vosk~=0.1,>=0.1.4
 
 # PHAL Plugins
 neon-phal-plugin-monitoring~=0.0.2,>=0.0.3a1
 neon-phal-plugin-audio-receiver~=0.0.4
 neon-phal-plugin-reset~=0.4,>=0.4.2a1
-neon-phal-plugin-device-updater~=0.3
+neon-phal-plugin-device-updater~=0.3,>=0.3.1a1
 neon-phal-plugin-fan~=0.1,>=0.1.1a2
 neon-phal-plugin-switches~=0.0.5,>=0.0.6a1
 neon-phal-plugin-linear_led~=0.2,>=0.2.4a1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,8 +20,8 @@ click-default-group~=1.2
 mock~=5.0
 
 # default plugins
-neon-lang-plugin-libretranslate~=0.2
-neon-utterance-translator-plugin~=0.2,>=0.2.1a1
+neon-lang-plugin-libretranslate~=0.2,>=0.2.1a2
+neon-utterance-translator-plugin~=0.2,>=0.2.1a2
 neon-utterance-normalizer-plugin~=0.1,>=0.1.1a1
 
 # Ensure uk-ua language support


### PR DESCRIPTION
# Description
Update Neon-maintained dependencies to prep for ovos-core 0.0.8 support

# Issues
Related to https://github.com/NeonGeckoCom/NeonCore/pull/708

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->