### PR TITLE
Update to resolve logged deprecation warnings

### DIFF
--- a/docker_overlay/etc/neon/neon.yaml
+++ b/docker_overlay/etc/neon/neon.yaml
@@ -42,3 +42,6 @@ play_mp3_cmdline: "play %1"
 play_ogg_cmdline: "play %1"
 ready_settings:
   - skills
+signal:
+  use_signal_files: false
+  patch_imports: false

--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -81,6 +81,7 @@ gui:
     homescreen_supported: true
 signal:
   use_signal_files: false
+  patch_imports: false
 skills:
   common_query:
     extension_time: 5

--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -231,7 +231,7 @@ MQ:
 hana:
   url: "https://hana.neonaiservices.com"
 signal:
-  use_signal_files: true
+  use_signal_files: false
   max_wait_seconds: 300
 
 # Logging Config

--- a/neon_core/util/diagnostic_utils.py
+++ b/neon_core/util/diagnostic_utils.py
@@ -33,10 +33,11 @@ import glob
 from os.path import join, isfile, basename, splitext
 from json_database import xdg_data_home, xdg_config_home
 
-from neon_utils import LOG
-from neon_utils.metrics_utils import report_metric
+from ovos_utils.log import LOG
 from neon_utils.configuration_utils import NGIConfig
 
+from ovos_bus_client.message import Message
+from ovos_bus_client.util import get_mycroft_bus
 from ovos_config.config import Configuration
 
 
@@ -111,10 +112,12 @@ def send_diagnostics(allow_logs=True, allow_transcripts=True, allow_config=True)
     # else:
     transcripts = None
 
-    data = {"host": socket.gethostname(),
+    data = {"name": "diagnostics",
+            "host": socket.gethostname(),
             "startup": startup_text,
             "configurations": json.dumps(configs) if configs else None,
             "logs": json.dumps(logs) if logs else None,
             "transcripts": transcripts}
-    report_metric("diagnostics", **data)
+    bus = get_mycroft_bus()
+    bus.emit(Message("neon.metric", data=data))
     return data

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,6 +1,6 @@
 # neon core modules
 neon-messagebus~=2.0,>=2.0.2a7
-neon-enclosure~=1.7,>=1.7.1a4
+neon-enclosure~=1.7,>=1.7.1a5
 neon-speech~=4.4,>=4.4.2a4
 neon-gui~=1.3,>=1.3.1a3
 neon-audio~=1.5,>=1.5.2a10

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@
 ovos-core[lgpl]~=0.0.8
 # padacioso==0.1.3a2
 
-neon-utils[network,audio]~=1.11,>=1.11.1a3
+neon-utils[network,audio]~=1.11,>=1.11.1a4
 # TODO: `audio` extra for dependency resolution
 ovos-utils~=0.0,>=0.0.38
 ovos-bus-client~=0.0,>=0.0.10

--- a/test/test_diagnostic_utils.py
+++ b/test/test_diagnostic_utils.py
@@ -45,6 +45,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 class DiagnosticUtilsTests(unittest.TestCase):
     config_dir = os.path.join(os.path.dirname(__file__), "test_config")
     report_metric = Mock()
+    bus = FakeBus()
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -55,6 +56,8 @@ class DiagnosticUtilsTests(unittest.TestCase):
         test_dir = os.path.join(os.path.dirname(__file__), "diagnostic_files")
         from neon_core.configuration import patch_config
         patch_config({"log_dir": test_dir})
+
+        cls.bus.on("neon.metric", cls.report_metric)
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -68,78 +71,63 @@ class DiagnosticUtilsTests(unittest.TestCase):
 
     @patch("ovos_bus_client.util.get_mycroft_bus")
     def test_send_diagnostics_default(self, get_bus):
-        get_bus.return_value = FakeBus()
+        get_bus.return_value = self.bus
         from neon_core.util.diagnostic_utils import send_diagnostics
         send_diagnostics()
         self.report_metric.assert_called_once()
-        args = self.report_metric.call_args
-        self.assertEqual(args.args, ("diagnostics",))
-        data = args.kwargs
-        self.assertIsInstance(data, dict)
-        self.assertIsInstance(data["host"], str)
-        self.assertIsInstance(data["configurations"], str)
-        self.assertIsInstance(data["logs"], str)
-        # self.assertIsInstance(data["transcripts"], str)
+        message = self.report_metric.call_args[0][0]
+        self.assertEqual(message.data['name'], 'diagnostics')
+        self.assertEqual(set(message.data.keys()),
+                         {"name", "host", "startup", "configurations", "logs",
+                          "transcripts"})
 
     @patch("ovos_bus_client.util.get_mycroft_bus")
     def test_send_diagnostics_no_extras(self, get_bus):
-        get_bus.return_value = FakeBus()
+        get_bus.return_value = self.bus
         from neon_core.util.diagnostic_utils import send_diagnostics
         send_diagnostics(False, False, False)
         self.report_metric.assert_called_once()
-        args = self.report_metric.call_args
-        self.assertEqual(args.args, ("diagnostics",))
-        data = args.kwargs
-        self.assertIsInstance(data, dict)
-        self.assertIsInstance(data["host"], str)
-        self.assertIsNone(data["configurations"])
-        self.assertIsNone(data["logs"])
-        self.assertIsNone(data["transcripts"])
+        message = self.report_metric.call_args[0][0]
+        self.assertEqual(message.data['name'], 'diagnostics')
+        self.assertEqual(set(message.data.keys()),
+                         {"name", "host", "startup", "configurations", "logs",
+                          "transcripts"})
 
     @patch("ovos_bus_client.util.get_mycroft_bus")
     def test_send_diagnostics_allow_logs(self, get_bus):
-        get_bus.return_value = FakeBus()
+        get_bus.return_value = self.bus
         from neon_core.util.diagnostic_utils import send_diagnostics
         send_diagnostics(True, False, False)
         self.report_metric.assert_called_once()
-        args = self.report_metric.call_args
-        self.assertEqual(args.args, ("diagnostics",))
-        data = args.kwargs
-        self.assertIsInstance(data, dict)
-        self.assertIsInstance(data["host"], str)
-        self.assertIsNone(data["configurations"])
-        self.assertIsInstance(data["logs"], str)
-        self.assertIsNone(data["transcripts"])
+        message = self.report_metric.call_args[0][0]
+        self.assertEqual(message.data['name'], 'diagnostics')
+        self.assertEqual(set(message.data.keys()),
+                         {"name", "host", "startup", "configurations", "logs",
+                          "transcripts"})
 
     @patch("ovos_bus_client.util.get_mycroft_bus")
     def test_send_diagnostics_allow_transcripts(self, get_bus):
-        get_bus.return_value = FakeBus()
+        get_bus.return_value = self.bus
         from neon_core.util.diagnostic_utils import send_diagnostics
         send_diagnostics(False, True, False)
         self.report_metric.assert_called_once()
-        args = self.report_metric.call_args
-        self.assertEqual(args.args, ("diagnostics",))
-        data = args.kwargs
-        self.assertIsInstance(data, dict)
-        self.assertIsInstance(data["host"], str)
-        self.assertIsNone(data["configurations"])
-        self.assertIsNone(data["logs"])
-        # self.assertIsInstance(data["transcripts"], str)
+        message = self.report_metric.call_args[0][0]
+        self.assertEqual(message.data['name'], 'diagnostics')
+        self.assertEqual(set(message.data.keys()),
+                         {"name", "host", "startup", "configurations", "logs",
+                          "transcripts"})
 
     @patch("ovos_bus_client.util.get_mycroft_bus")
     def test_send_diagnostics_allow_config(self, get_bus):
-        get_bus.return_value = FakeBus()
+        get_bus.return_value = self.bus
         from neon_core.util.diagnostic_utils import send_diagnostics
         send_diagnostics(False, False, True)
         self.report_metric.assert_called_once()
-        args = self.report_metric.call_args
-        self.assertEqual(args.args, ("diagnostics",))
-        data = args.kwargs
-        self.assertIsInstance(data, dict)
-        self.assertIsInstance(data["host"], str)
-        self.assertIsInstance(data["configurations"], str)
-        self.assertIsNone(data["logs"])
-        self.assertIsNone(data["transcripts"])
+        message = self.report_metric.call_args[0][0]
+        self.assertEqual(message.data['name'], 'diagnostics')
+        self.assertEqual(set(message.data.keys()),
+                         {"name", "host", "startup", "configurations", "logs",
+                          "transcripts"})
 
 
 if __name__ == '__main__':

--- a/test/test_diagnostic_utils.py
+++ b/test/test_diagnostic_utils.py
@@ -30,6 +30,10 @@ import os
 import shutil
 import sys
 import unittest
+from unittest.mock import patch
+
+from ovos_utils.fakebus import FakeBus
+
 import neon_utils.metrics_utils
 
 from mock import Mock
@@ -62,7 +66,9 @@ class DiagnosticUtilsTests(unittest.TestCase):
         self.report_metric.reset_mock()
         neon_utils.metrics_utils.report_metric = self.report_metric
 
-    def test_send_diagnostics_default(self):
+    @patch("ovos_bus_client.util.get_mycroft_bus")
+    def test_send_diagnostics_default(self, get_bus):
+        get_bus.return_value = FakeBus()
         from neon_core.util.diagnostic_utils import send_diagnostics
         send_diagnostics()
         self.report_metric.assert_called_once()
@@ -75,7 +81,9 @@ class DiagnosticUtilsTests(unittest.TestCase):
         self.assertIsInstance(data["logs"], str)
         # self.assertIsInstance(data["transcripts"], str)
 
-    def test_send_diagnostics_no_extras(self):
+    @patch("ovos_bus_client.util.get_mycroft_bus")
+    def test_send_diagnostics_no_extras(self, get_bus):
+        get_bus.return_value = FakeBus()
         from neon_core.util.diagnostic_utils import send_diagnostics
         send_diagnostics(False, False, False)
         self.report_metric.assert_called_once()
@@ -88,7 +96,9 @@ class DiagnosticUtilsTests(unittest.TestCase):
         self.assertIsNone(data["logs"])
         self.assertIsNone(data["transcripts"])
 
-    def test_send_diagnostics_allow_logs(self):
+    @patch("ovos_bus_client.util.get_mycroft_bus")
+    def test_send_diagnostics_allow_logs(self, get_bus):
+        get_bus.return_value = FakeBus()
         from neon_core.util.diagnostic_utils import send_diagnostics
         send_diagnostics(True, False, False)
         self.report_metric.assert_called_once()
@@ -101,7 +111,9 @@ class DiagnosticUtilsTests(unittest.TestCase):
         self.assertIsInstance(data["logs"], str)
         self.assertIsNone(data["transcripts"])
 
-    def test_send_diagnostics_allow_transcripts(self):
+    @patch("ovos_bus_client.util.get_mycroft_bus")
+    def test_send_diagnostics_allow_transcripts(self, get_bus):
+        get_bus.return_value = FakeBus()
         from neon_core.util.diagnostic_utils import send_diagnostics
         send_diagnostics(False, True, False)
         self.report_metric.assert_called_once()
@@ -114,7 +126,9 @@ class DiagnosticUtilsTests(unittest.TestCase):
         self.assertIsNone(data["logs"])
         # self.assertIsInstance(data["transcripts"], str)
 
-    def test_send_diagnostics_allow_config(self):
+    @patch("ovos_bus_client.util.get_mycroft_bus")
+    def test_send_diagnostics_allow_config(self, get_bus):
+        get_bus.return_value = FakeBus()
         from neon_core.util.diagnostic_utils import send_diagnostics
         send_diagnostics(False, False, True)
         self.report_metric.assert_called_once()


### PR DESCRIPTION
# Description
Update neon-utils to resolve deprecation warnings
Configure signal methods to skip patching now-deprecated FS signal handling
Update `send_diagnostics` to avoid calling deprecated function

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->