### PR TITLE
Load system plugin with Admin Enclosure service

### DIFF
--- a/neon_core/configuration/mark_2/neon.yaml
+++ b/neon_core/configuration/mark_2/neon.yaml
@@ -103,8 +103,6 @@ PHAL:
     color: "#ff8600"
     portal: start dot neon dot ai
     device: Neon Device
-  ovos-PHAL-plugin-system:
-    core_service: neon.service
   neon-phal-plugin-linear-led:
     mute_color: burnt_orange
     sleep_color: red
@@ -112,6 +110,9 @@ PHAL:
   neon-phal-plugin-fan:
     min_fan_temp: 40.0
   admin:
+    ovos-PHAL-plugin-system:
+      enabled: true
+      core_service: neon.service
     neon-phal-plugin-device-updater:
       enabled: true
       initramfs_url: "https://github.com/NeonGeckoCom/neon_debos/raw/{}/overlays/02-rpi4/boot/firmware/initramfs"

--- a/neon_core/configuration/opi5/neon.yaml
+++ b/neon_core/configuration/opi5/neon.yaml
@@ -86,8 +86,6 @@ PHAL:
     color: '#ff8600'
     portal: start dot neon dot ai
     device: Neon Device
-  ovos-PHAL-plugin-system:
-    core_service: neon.service
   neon-phal-plugin-linear-led:
     mute_color: burnt_orange
     sleep_color: red
@@ -95,6 +93,9 @@ PHAL:
   neon-phal-plugin-fan:
     min_fan_temp: 40.0
   admin:
+    ovos-PHAL-plugin-system:
+      enabled: true
+      core_service: neon.service
     neon-phal-plugin-device-updater:
       enabled: true
       initramfs_url: "https://github.com/NeonGeckoCom/neon_debos/raw/{}/overlays/02-opi5/boot/uInitrd"

--- a/neon_core/configuration/rpi4/neon.yaml
+++ b/neon_core/configuration/rpi4/neon.yaml
@@ -86,8 +86,6 @@ PHAL:
     color: '#ff8600'
     portal: start dot neon dot ai
     device: Neon Device
-  ovos-PHAL-plugin-system:
-    core_service: neon.service
   neon-phal-plugin-linear-led:
     mute_color: burnt_orange
     sleep_color: red
@@ -95,6 +93,9 @@ PHAL:
   neon-phal-plugin-fan:
     min_fan_temp: 40.0
   admin:
+    ovos-PHAL-plugin-system:
+      enabled: true
+      core_service: neon.service
     neon-phal-plugin-device-updater:
       enabled: true
       initramfs_url: "https://github.com/NeonGeckoCom/neon_debos/raw/{}/overlays/02-rpi4/boot/firmware/initramfs"


### PR DESCRIPTION
# Description
Update default system plugin configuration to load with the admin enclosure service to resolve permissions errors

# Issues
Closes #721

# Other Notes
Previously, the shutdown/restart commands prefixed `sudo`; this does not follow the general pattern of using the admin service for anything requiring escalated privileges.