### PR TITLE
Patch breaking change to language handling and Patch imports to resolve deprecation warnings

### DIFF
--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -31,3 +31,27 @@ from os.path import join, dirname
 
 environ["OVOS_DEFAULT_CONFIG"] = join(dirname(__file__),
                                       "configuration", "neon.yaml")
+
+# Patching deprecation warnings
+# TODO: Deprecate after migration to ovos-workshop 1.0+ and ovos-core 0.1+
+import ovos_workshop.resource_files
+import ovos_core.intent_services.stop_service
+from ovos_utils.bracket_expansion import expand_template
+ovos_workshop.resource_files.expand_options = expand_template
+ovos_core.intent_services.stop_service.expand_options = expand_template
+
+
+# Patching backwards-compat. intent language codes
+import ovos_core.intent_services
+from ovos_bus_client.util import get_message_lang
+
+
+def _patched_get_message_lang(*args, **kwargs):
+    # https://github.com/OpenVoiceOS/ovos-utils/pull/267 started normalizing
+    # lang codes to `en-US`, where previously this would be `en-us`. This
+    # patches the intent_service to use the lowercase tags for improved
+    # backwards-compatibility
+    return get_message_lang(*args, **kwargs).lower()
+
+
+ovos_core.intent_services.get_message_lang = _patched_get_message_lang

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,10 +2,11 @@
 ovos-core[lgpl]~=0.0.8
 # padacioso==0.1.3a2
 
-neon-utils[network,audio]~=1.11,>=1.11.1a7
-# TODO: `audio` extra for dependency resolution
-ovos-utils~=0.0,>=0.0.38,<0.6.0
-# TODO: ovos-utils 0.6 constraint added to minimize deprecation logs on startup
+# TODO ovos-classifiers required for common-play
+ovos-classifiers
+
+neon-utils[network]~=1.12
+ovos-utils~=0.0,>=0.0.38
 ovos-bus-client~=0.0,>=0.0.10
 neon-transformers~=0.2,>=0.2.1a4
 ovos-config~=0.0,>=0.0.12


### PR DESCRIPTION
# Description
Patch out deprecation warnings not resolved in compatible upstream ovos-workshop and ovos-core versions
Patch language code handling in the intent service

# Issues
New langcode normalization added in https://github.com/OpenVoiceOS/ovos-utils/pull/267
Breaking change in behavior introduced by https://github.com/OpenVoiceOS/ovos-bus-client/pull/128

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->