### PR TITLE
Update wallpaper manager plugin to resolve missing default

### DIFF
--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -48,7 +48,7 @@ ovos-phal-plugin-oauth~=0.1
 ovos-phal-plugin-alsa~=0.0,>=0.0.3
 ovos-phal-plugin-connectivity-events~=0.1
 ovos-phal-plugin-homeassistant~=0.0.3,>=0.0.4a5
-ovos-phal-plugin-wallpaper-manager~=0.2
+ovos-phal-plugin-wallpaper-manager~=0.2,>=0.2.1a1
 ovos-phal-plugin-ipgeo~=0.1
 ovos-phal-plugin-mk1 @ git+https://github.com/openvoiceos/ovos-phal-plugin-mk1@dev
 # TODO: Stable spec for mk1 plugin


### PR DESCRIPTION
# Description
Update wallpaper plugin to resolve observed issue where default wallpaper is missing from options

# Issues
- Implements https://github.com/OpenVoiceOS/ovos-PHAL-plugin-wallpaper-manager/pull/24
- Needs https://github.com/OpenVoiceOS/ovos-PHAL-plugin-wallpaper-manager/pull/26

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->