### PR TITLE
Deprecate `PIDLock` usage and update Dockerfile to resolve warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.10-slim as base
+FROM python:3.10-slim AS base
 
 LABEL vendor=neon.ai \
     ai.neon.name="neon-skills"
 
-ENV OVOS_CONFIG_BASE_FOLDER neon
-ENV OVOS_CONFIG_FILENAME neon.yaml
-ENV XDG_CONFIG_HOME /config
+ENV OVOS_CONFIG_BASE_FOLDER=neon
+ENV OVOS_CONFIG_FILENAME=neon.yaml
+ENV XDG_CONFIG_HOME=/config
 
 RUN  apt-get update && \
      apt-get install -y \
@@ -53,6 +53,6 @@ RUN chmod ugo+x /root/run.sh && \
 
 CMD ["/root/run.sh"]
 
-FROM base as default_skills
+FROM base AS default_skills
 RUN pip install .[skills_required,skills_essential,skills_default,skills_extended]
 # Default skills from configuration are installed at container creation

--- a/neon_core/skills/__main__.py
+++ b/neon_core/skills/__main__.py
@@ -29,15 +29,13 @@
 from neon_core.skills.service import NeonSkillService
 from neon_utils.log_utils import init_log
 from ovos_utils.log import LOG
-from ovos_utils.process_utils import reset_sigint_handler, PIDLock as Lock
+from ovos_utils.process_utils import reset_sigint_handler
 from ovos_utils import wait_for_exit_signal
 from neon_utils.process_utils import start_malloc, snapshot_malloc, print_malloc
 
 
 def main(*args, **kwargs):
     reset_sigint_handler()
-    # Create PID file, prevent multiple instances of this service
-    Lock('skills')
     init_log(log_name="skills")
     malloc_running = start_malloc(stack_depth=4)
     service = NeonSkillService(*args, **kwargs)

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,6 +1,6 @@
 # neon core modules
 neon-messagebus~=2.0,>=2.0.2a10
-neon-enclosure~=1.7,>=1.7.1a8
+neon-enclosure~=1.7,>=1.7.1a7
 neon-speech~=4.4,>=4.4.2a7
 neon-gui~=1.3,>=1.3.1a5
 neon-audio~=1.5,>=1.5.2a12

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,6 +1,6 @@
 # neon core modules
-neon-messagebus~=2.0,>=2.0.2a7
-neon-enclosure~=1.7,>=1.7.1a5
-neon-speech~=4.4,>=4.4.2a5
-neon-gui~=1.3,>=1.3.1a3
-neon-audio~=1.5,>=1.5.2a10
+neon-messagebus~=2.0,>=2.0.2a10
+neon-enclosure~=1.7,>=1.7.1a8
+neon-speech~=4.4,>=4.4.2a7
+neon-gui~=1.3,>=1.3.1a5
+neon-audio~=1.5,>=1.5.2a12

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -27,6 +27,3 @@ neon-utterance-normalizer-plugin~=0.1,>=0.1.1a1
 
 # Ensure uk-ua language support
 ovos-lingua-franca~=0.4,>=0.4.8a13
-
-# TODO: Below adding support for latest OVOS package resolution
-neon-mq-connector>=0.7.2a3


### PR DESCRIPTION
# Description
Deprecate `PIDLock` initialization
Resolve Dockerfile warnings
Update `core_modules` dependencies to versions that also remove PIDLock init

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->