### PR TITLE
Update neon-audio core module dependency

### DIFF
--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -3,4 +3,4 @@ neon-messagebus~=2.0,>=2.0.2a10
 neon-enclosure~=1.7,>=1.7.1a7
 neon-speech~=4.4,>=4.4.2a7
 neon-gui~=1.3,>=1.3.1a5
-neon-audio~=1.5,>=1.5.2a12
+neon-audio~=1.5,>=1.5.2a13


### PR DESCRIPTION
# Description
Update audio module to resolve observed Mark2 errors around `get_response`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->