### PR TITLE
Update core module dependencies to latest alpha versions

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -7,4 +7,4 @@ jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
     with:
-      packages-exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|audioread).*'
+      packages-exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|audioread|RapidFuzz).*'

--- a/.github/workflows/setup_tests.yml
+++ b/.github/workflows/setup_tests.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           optimize_image: false
           base_image: file://${{ github.workspace }}/pi_image_3.img.xz
-          cpu: cortex-a76
+          cpu: cortex-a53
           copy_repository_path: /core
           commands: |
             bash /core/test/pi_setup_3_10.sh || exit 2
@@ -92,7 +92,7 @@ jobs:
         with:
           optimize_image: false
           base_image: file://${{ github.workspace }}/pi_image_3.img.xz
-          cpu: cortex-a76
+          cpu: cortex-a53
           copy_repository_path: /core
           commands: |
             bash /core/test/pi_setup_3_11.sh || exit 2

--- a/.github/workflows/setup_tests.yml
+++ b/.github/workflows/setup_tests.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           optimize_image: false
           base_image: file://${{ github.workspace }}/pi_image_3.img.xz
-          cpu: cortex-a53
+          cpu: cortex-a76
           copy_repository_path: /core
           commands: |
             bash /core/test/pi_setup_3_10.sh || exit 2
@@ -92,7 +92,7 @@ jobs:
         with:
           optimize_image: false
           base_image: file://${{ github.workspace }}/pi_image_3.img.xz
-          cpu: cortex-a53
+          cpu: cortex-a76
           copy_repository_path: /core
           commands: |
             bash /core/test/pi_setup_3_11.sh || exit 2

--- a/requirements/core_modules.txt
+++ b/requirements/core_modules.txt
@@ -1,6 +1,6 @@
 # neon core modules
-neon-messagebus~=2.0,>=2.0.2a10
-neon-enclosure~=1.7,>=1.7.1a7
+neon-messagebus~=2.0,>=2.0.2a12
+neon-enclosure~=1.7,>=1.7.1a9
 neon-speech~=4.4,>=4.4.2a7
 neon-gui~=1.3,>=1.3.1a5
-neon-audio~=1.5,>=1.5.2a13
+neon-audio~=1.5,>=1.5.2a15

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -12,7 +12,7 @@ neon-mana-utils~=0.2,>=0.2.3a2
 
 # Default plugins
 ovos-vad-plugin-silero~=0.0.1
-onnxruntime!=1.16.0  # TODO: Patching https://github.com/microsoft/onnxruntime/issues/17631
+onnxruntime!=1.16.0,!=1.21.0  # TODO: Patching https://github.com/microsoft/onnxruntime/issues/17631 and https://github.com/microsoft/onnxruntime/issues/23957
 ovos-ww-plugin-precise~=0.1
 ovos-ww-plugin-precise-lite[tflite]~=0.1,>=0.1.2
 ovos-ww-plugin-vosk~=0.1,>=0.1.1


### PR DESCRIPTION
# Description
Update core_modules to validate latest alpha version compat.

# Issues
Blacklists an onnxruntime version to mitigate https://github.com/microsoft/onnxruntime/issues/23957

# Other Notes
Based on [this run from an old tag failing](https://github.com/NeonGeckoCom/NeonCore/actions/runs/13816049514/job/38649389777), it appears that the failures are related to some change in GitHub Actions runners or some low-level dependency change.

Cause for Pi image failures is unknown, but updating to a newer CPU arch in the shared action appears to resolve the issue. Note that the previously spec'd A53 was used in the RPi3 and the now spec'd A76 is used in the RPi5

Issue was traced back to a new onnxruntime release