### PR TITLE
Implement status server

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -6,5 +6,3 @@ on:
 jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
-    with:
-      packages-exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|audioread|RapidFuzz).*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN  curl https://forslund.github.io/mycroft-desktop-repo/mycroft-desktop.gpg.ke
 
 RUN apt-get update && \
     apt-get install -y \
+    curl \
+    jq \
     gcc \
     g++ \
     python3-dev \
@@ -41,18 +43,19 @@ RUN apt-get update && \
 # TODO: git required for getting scripts, skill should be refactored to remove this dependency
 # TODO: sox, mimic required for demo skill, audio service should be refactored to handle TTS engines/voices in request
 
-ADD . /neon_core
+COPY . /neon_core
 WORKDIR /neon_core
 
-RUN pip install wheel && \
-    pip install .[docker]
+RUN pip install --no-cache-dir wheel && \
+    pip install --no-cache-dir .[docker]
 
 COPY docker_overlay/ /
 RUN chmod ugo+x /root/run.sh && \
     neon update-default-resources
 
+HEALTHCHECK CMD "/opt/neon/healthcheck.sh"
 CMD ["/root/run.sh"]
 
 FROM base AS default_skills
-RUN pip install .[skills_required,skills_essential,skills_default,skills_extended]
+RUN pip install --no-cache-dir .[skills_required,skills_essential,skills_default,skills_extended]
 # Default skills from configuration are installed at container creation

--- a/docker_overlay/opt/neon/healthcheck.sh
+++ b/docker_overlay/opt/neon/healthcheck.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
-# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
 # Copyright 2008-2025 Neongecko.com Inc.
-# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
-# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
-# BSD-3 License
+# BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 # 1. Redistributions of source code must retain the above copyright notice,
@@ -27,6 +25,13 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Python package installation must occur in a separate thread, before module load, for the entry point to be loaded.
-neon install-default-skills
-neon run-skills -hp 8000
+port=8000
+# Perform the health check using curl
+resp_content=$(curl -s http://localhost:${port}/status)
+status=$(echo "${resp_content}" | jq -r '.status')
+if [ "${status}" == "Ready" ]; then
+  exit 0  # Success
+else
+  echo "Health check failed with response: ${resp_content}" >&2
+  exit 1  # Failure
+fi

--- a/neon_core/cli.py
+++ b/neon_core/cli.py
@@ -29,24 +29,33 @@
 
 import click
 
+from typing import Optional
 from os import environ
 from os.path import join, dirname
 from threading import Thread
 from click_default_group import DefaultGroup
 from neon_utils.packaging_utils import get_neon_core_version
 
-_DEFAULT_CONFIG_FILE = join(dirname(__file__), 'configuration', 'neon.yaml')
+_DEFAULT_CONFIG_FILE = join(dirname(__file__), "configuration", "neon.yaml")
 environ.setdefault("OVOS_CONFIG_BASE_FOLDER", "neon")
 environ.setdefault("OVOS_CONFIG_FILENAME", "neon.yaml")
 environ.setdefault("OVOS_DEFAULT_CONFIG", _DEFAULT_CONFIG_FILE)
 
 
-@click.group("neon", cls=DefaultGroup,
-             no_args_is_help=True, invoke_without_command=True,
-             help="Neon Core Commands\n\n"
-                  "See also: neon COMMAND --help")
-@click.option("--version", "-v", is_flag=True, required=False,
-              help="Print the current version")
+@click.group(
+    "neon",
+    cls=DefaultGroup,
+    no_args_is_help=True,
+    invoke_without_command=True,
+    help="Neon Core Commands\n\nSee also: neon COMMAND --help",
+)
+@click.option(
+    "--version",
+    "-v",
+    is_flag=True,
+    required=False,
+    help="Print the current version",
+)
 def neon_core_cli(version: bool = False):
     if version:
         click.echo(f"Neon version {get_neon_core_version()}")
@@ -55,6 +64,7 @@ def neon_core_cli(version: bool = False):
 @neon_core_cli.command(help="Start Neon Core")
 def start_neon():
     from neon_core.run_neon import start_neon
+
     click.echo("Starting Neon")
     Thread(target=start_neon, daemon=False).start()
     click.echo("Neon Started")
@@ -63,20 +73,31 @@ def start_neon():
 @neon_core_cli.command(help="Stop Neon Core")
 def stop_neon():
     from neon_core.run_neon import stop_neon
+
     click.echo("Stopping Neon")
     stop_neon()
     click.echo("Neon Stopped")
 
 
 @neon_core_cli.command(help="Send Diagnostics")
-@click.option("--no-transcripts", is_flag=True, default=False,
-              help="Skip upload of transcript files")
-@click.option("--no-logs", is_flag=True, default=False,
-              help="Skip upload of log files")
-@click.option("--no-config", is_flag=True, default=False,
-              help="Skip upload of configuration files")
+@click.option(
+    "--no-transcripts",
+    is_flag=True,
+    default=False,
+    help="Skip upload of transcript files",
+)
+@click.option(
+    "--no-logs", is_flag=True, default=False, help="Skip upload of log files"
+)
+@click.option(
+    "--no-config",
+    is_flag=True,
+    default=False,
+    help="Skip upload of configuration files",
+)
 def upload_diagnostics(no_transcripts, no_logs, no_config):
     from neon_core.util.diagnostic_utils import send_diagnostics
+
     click.echo("Uploading Diagnostics")
     send_diagnostics(not no_logs, not no_transcripts, not no_config)
     click.echo("Diagnostic Upload Complete")
@@ -85,6 +106,7 @@ def upload_diagnostics(no_transcripts, no_logs, no_config):
 @neon_core_cli.command(help="Install Default Skills")
 def install_default_skills():
     from neon_core.util.skill_utils import install_skills_default
+
     click.echo("Installing Default Skills")
     install_skills_default()
     click.echo("Default Skills Installed")
@@ -93,16 +115,26 @@ def install_default_skills():
 @neon_core_cli.command(help="Ensure default resource files are available")
 def update_default_resources():
     from neon_core.util.skill_utils import update_default_resources
+
     click.echo("Updating Default Resources")
     update_default_resources()
 
 
 @neon_core_cli.command(help="Start Neon Skills module")
-def run_skills():
+@click.option(
+    "--health-check-server-port",
+    "-hp",
+    type=int,
+    default=None,
+    help="Port for health check server to listen on",
+)
+def run_skills(health_check_server_port: Optional[int] = None):
     from neon_core.util.skill_utils import update_default_resources
+
     update_default_resources()
 
     from neon_core.skills.__main__ import main
+
     click.echo("Starting Skills Service")
-    main()
+    main(health_check_server_port=health_check_server_port)
     click.echo("Skills Service Shutdown")

--- a/neon_core/skills/__main__.py
+++ b/neon_core/skills/__main__.py
@@ -31,14 +31,25 @@ from neon_utils.log_utils import init_log
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import reset_sigint_handler
 from ovos_utils import wait_for_exit_signal
-from neon_utils.process_utils import start_malloc, snapshot_malloc, print_malloc
+from neon_utils.process_utils import (
+    start_malloc,
+    snapshot_malloc,
+    print_malloc,
+)
 
 
 def main(*args, **kwargs):
     reset_sigint_handler()
     init_log(log_name="skills")
     malloc_running = start_malloc(stack_depth=4)
+    health_check_server_port = kwargs.pop("health_check_server_port", None)
     service = NeonSkillService(*args, **kwargs)
+    if health_check_server_port is not None:
+        from neon_utils.process_utils import start_health_check_server
+
+        start_health_check_server(
+            service.skill_manager.status, health_check_server_port, service.check_health
+        )
     try:
         service.start()
         wait_for_exit_signal()

--- a/neon_core/skills/service.py
+++ b/neon_core/skills/service.py
@@ -168,7 +168,6 @@ class NeonSkillService(Thread):
         self.event_scheduler.start()
         SkillApi.connect_bus(self.bus)
         LOG.info("Starting Skill Manager")
-        self.skill_manager.bus = self.bus
         self.skill_manager.start()
         LOG.info("Skill Manager started")
 

--- a/neon_core/skills/service.py
+++ b/neon_core/skills/service.py
@@ -76,12 +76,13 @@ class NeonSkillService(Thread):
                  error_hook: callable = on_error,
                  stopping_hook: callable = on_stopping,
                  watchdog: Optional[callable] = None,
+                 bus: Optional[MessageBusClient] = None,
                  config: Optional[dict] = None, daemonic: bool = False):
         Thread.__init__(self)
         LOG.debug("Starting Skills Service")
         self._status_from_bus_connection = False
         self.daemon = daemonic
-        self.bus: MessageBusClient = get_messagebus(timeout=300)
+        self.bus: MessageBusClient = bus or get_messagebus(timeout=300)
         self.http_server = None
         self.event_scheduler = None
         self.watchdog = watchdog

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,8 @@ ovos-core[lgpl]~=0.0.8
 # TODO ovos-classifiers required for common-play
 ovos-classifiers
 
-neon-utils[network]~=1.12
+#neon-utils[network]~=1.12
+neon-utils[network] @ git+https://github.com/neongeckocom/neon-utils@FEAT_HttpStatusServer#egg=neon-utils
 ovos-utils~=0.0,>=0.0.38
 ovos-bus-client~=0.0,>=0.0.10
 neon-transformers~=1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,8 +5,7 @@ ovos-core[lgpl]~=0.0.8
 # TODO ovos-classifiers required for common-play
 ovos-classifiers
 
-#neon-utils[network]~=1.12
-neon-utils[network] @ git+https://github.com/neongeckocom/neon-utils@FEAT_HttpStatusServer#egg=neon-utils
+neon-utils[network]~=1.12,>=1.12.2a2
 ovos-utils~=0.0,>=0.0.38
 ovos-bus-client~=0.0,>=0.0.10
 neon-transformers~=1.0

--- a/test/test_skills_module.py
+++ b/test/test_skills_module.py
@@ -121,7 +121,7 @@ class TestSkillService(unittest.TestCase):
         run.side_effect = ready_hook
         service = NeonSkillService(alive_hook, started_hook, ready_hook,
                                    error_hook, stopping_hook, config=config,
-                                   daemonic=True)
+                                   daemonic=True, bus=FakeBus())
         from neon_core.configuration import Configuration
         self.assertEqual(service.config, Configuration())
         self.assertIsInstance(Configuration()["location"]["timezone"], dict)
@@ -160,7 +160,7 @@ class TestSkillService(unittest.TestCase):
                                             "skill-plugin")],
                                       ["skill-plugin.neongeckocom"])
 
-        skill_dirs = NeonSkillService()._get_skill_dirs()
+        skill_dirs = NeonSkillService(bus=FakeBus())._get_skill_dirs()
         # listdir doesn't guarantee order, base skill directory order matters
         self.assertEqual(set(skill_dirs),
                          {join(test_dir, "plugins", "skill-plugin"),


### PR DESCRIPTION
# Description
Refactor `skill_manager` initializaiton from `run` to `init`
Includes Python file formatting changes
Adds a CLI option to enable health check server on a specified port
Adds a script and updates Dockerfile to enable Docker health checks

# Issues
- Needs https://github.com/NeonGeckoCom/neon-utils/pull/551

# Other Notes
- [x] Validate functionality on Mark2 with SkillManager refactor