### PR TITLE
Update skill installation to force-reinstall git skills

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   license_tests:
-    uses: neongeckocom/.github/.github/workflows/license_tests.yml@FEAT_UpdateLicenseTestAction
+    uses: neongeckocom/.github/.github/workflows/license_tests.yml@master


### PR DESCRIPTION
# Description
If installing a skill from git which is already in the container, it is often skipped unless the version has already been incremented. This change ensures that all `git` extra skills are installed

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Does lead to a slight slowdown during container init, but should be negligible in most cases since there are very few additional skills available to install