### PR TITLE
Re-implement `mycroft.ready` event emit with service status checks

### DIFF
--- a/neon_core/__init__.py
+++ b/neon_core/__init__.py
@@ -31,6 +31,8 @@ from os.path import join, dirname
 
 environ["OVOS_DEFAULT_CONFIG"] = join(dirname(__file__),
                                       "configuration", "neon.yaml")
+environ.setdefault('OVOS_CONFIG_BASE_FOLDER', "neon")
+environ.setdefault('OVOS_CONFIG_FILENAME', "neon.yaml")
 
 # Patching deprecation warnings
 # TODO: Deprecate after migration to ovos-workshop 1.0+ and ovos-core 0.3.0

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -38,6 +38,8 @@ class NeonSkillManager(SkillManager):
     def _define_message_bus_events(self):
         # Overriding to use overridden handlers in this class
         SkillManager._define_message_bus_events(self)
+        self.bus.remove_all_listeners("mycroft.skills.trained")
+        self.bus.once("mycroft.skills.trained", self.handle_initial_training)
 
     def get_default_skills_dir(self):
         """

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -111,12 +111,11 @@ class NeonSkillManager(SkillManager):
             for service in ready_services:
                 if not ready_services[service]:
                     resp = self.bus.wait_for_response(Message(f"mycroft.{service}.is_ready", context={"source": ["skills"], "destination": [service]}))
-                    LOG.info(resp.data if resp else f"No response for service={service}")  # TODO: Log to be downgraded to debug
-                    service_ready = resp and resp.data.get("status") == "ready"
+                    LOG.debug(resp.data if resp else f"No response for service={service}")  # TODO: Log to be downgraded to debug
+                    service_ready = resp and resp.data.get("status")
                     if service_ready:
                         LOG.info(f"{service} reports ready")
                         ready_services[service] = service_ready
-            LOG.info(f"Services ready: {ready_services}")  # TODO: Log to be downgraded to debug
         LOG.info(f"All configured ready settings met: {ready_services}")
         self.bus.emit(Message("mycroft.ready", context={"source": ["skills"], "destination": valid_services}))
 

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -35,13 +35,13 @@ from ovos_core.skill_manager import SkillManager
 
 
 class NeonSkillManager(SkillManager):
-    def _load_on_startup(self):
+    def _sync_skill_loading_state(self):
         """
         Override to wait for configured ready settings before announcing the
         service is ready
         """
-        SkillManager._load_on_startup(self)
-        LOG.info(f"Waiting for skill ready settings")  # TODO Log is only for debugging
+        SkillManager._sync_skill_loading_state(self)
+        LOG.info("Waiting for skill ready settings")  # TODO Log is only for debugging
         self._wait_until_skills_ready()
 
     def get_default_skills_dir(self):

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -42,7 +42,9 @@ class NeonSkillManager(SkillManager):
         service is ready
         """
         SkillManager._sync_skill_loading_state(self)
-        LOG.info("Waiting for skill ready settings")  # TODO Log is only for debugging
+        LOG.info(
+            "Waiting for skill ready settings"
+        )  # TODO Log is only for debugging
         self._wait_until_skills_ready()
 
         # Start a background thread to check for configured ready settings
@@ -56,11 +58,14 @@ class NeonSkillManager(SkillManager):
         Go through legacy config params to locate the default skill directory
         """
         skill_config = self.config["skills"]
-        skill_dir = skill_config.get("directory") or \
-            skill_config.get("extra_directories")
-        skill_dir = skill_dir[0] if isinstance(skill_dir, list) and \
-            len(skill_dir) > 0 else skill_dir or \
-            join(xdg_data_home(), "neon", "skills")
+        skill_dir = skill_config.get("directory") or skill_config.get(
+            "extra_directories"
+        )
+        skill_dir = (
+            skill_dir[0]
+            if isinstance(skill_dir, list) and len(skill_dir) > 0
+            else skill_dir or join(xdg_data_home(), "neon", "skills")
+        )
 
         skill_dir = expanduser(skill_dir)
         if not isdir(skill_dir):
@@ -104,18 +109,42 @@ class NeonSkillManager(SkillManager):
         while not self._wait_until_skills_ready():
             LOG.warning("Skills not ready, still waiting...")
         ready_settings = self.config.get("ready_settings", ["skills"])
-        valid_services = ("skills", "voice", "audio", "gui_service", "internet")
-        ready_services = {s: False for s in ready_settings if s in valid_services}
+        valid_services = (
+            "skills",
+            "voice",
+            "audio",
+            "gui_service",
+            "internet",
+        )
+        ready_services = {
+            s: False for s in ready_settings if s in valid_services
+        }
         LOG.info(f"Waiting for services: {ready_services}")
         while not all(ready_services.values()):
             for service in ready_services:
                 if not ready_services[service]:
-                    resp = self.bus.wait_for_response(Message(f"mycroft.{service}.is_ready", context={"source": ["skills"], "destination": [service]}))
-                    LOG.debug(resp.data if resp else f"No response for service={service}")  # TODO: Log to be downgraded to debug
+                    resp = self.bus.wait_for_response(
+                        Message(
+                            f"mycroft.{service}.is_ready",
+                            context={
+                                "source": ["skills"],
+                                "destination": [service],
+                            },
+                        )
+                    )
+                    LOG.debug(
+                        resp.data
+                        if resp
+                        else f"No response for service={service}"
+                    )
                     service_ready = resp and resp.data.get("status")
                     if service_ready:
                         LOG.info(f"{service} reports ready")
                         ready_services[service] = service_ready
         LOG.info(f"All configured ready settings met: {ready_services}")
-        self.bus.emit(Message("mycroft.ready", context={"source": ["skills"], "destination": valid_services}))
-
+        self.bus.emit(
+            Message(
+                "mycroft.ready",
+                context={"source": ["skills"], "destination": valid_services},
+            )
+        )

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -87,7 +87,7 @@ class NeonSkillManager(SkillManager):
                 LOG.error("Timeout waiting for network skills to load")
                 return False
         if "internet_skills" in ready_settings:
-            if not self._internet_loaded.wait(self._internet_skill_timeout):
+            if not self._internet_loaded.wait(self._network_skill_timeout):
                 LOG.error("Timeout waiting for internet skills to load")
                 return False
         LOG.info(f"Configured ready settings met: {ready_settings}")

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -111,7 +111,7 @@ class NeonSkillManager(SkillManager):
             for service in ready_services:
                 if not ready_services[service]:
                     resp = self.bus.wait_for_response(Message(f"mycroft.{service}.is_ready", context={"source": ["skills"], "destination": [service]}))
-                    LOG.info(resp)  # TODO: Log to be downgraded to debug
+                    LOG.info(resp.data if resp else f"No response for service={service}")  # TODO: Log to be downgraded to debug
                     service_ready = resp and resp.data.get("status") == "ready"
                     if service_ready:
                         LOG.info(f"{service} reports ready")

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -35,11 +35,14 @@ from ovos_core.skill_manager import SkillManager
 
 
 class NeonSkillManager(SkillManager):
-    def _define_message_bus_events(self):
-        # Overriding to use overridden handlers in this class
-        SkillManager._define_message_bus_events(self)
-        self.bus.remove_all_listeners("mycroft.skills.trained")
-        self.bus.once("mycroft.skills.trained", self.handle_initial_training)
+    def _load_on_startup(self):
+        """
+        Override to wait for configured ready settings before announcing the
+        service is ready
+        """
+        SkillManager._load_on_startup(self)
+        LOG.info(f"Waiting for skill ready settings")  # TODO Log is only for debugging
+        self._wait_until_skills_ready()
 
     def get_default_skills_dir(self):
         """
@@ -65,10 +68,6 @@ class NeonSkillManager(SkillManager):
                     makedirs(skill_dir, exist_ok=True)
 
         return skill_dir
-
-    def _load_new_skills(self, *args, **kwargs):
-        # Override load method for config module checks
-        SkillManager._load_new_skills(self, *args, **kwargs)
 
     def _get_plugin_skill_loader(self, skill_id, init_bus=True):
         assert self.bus is not None
@@ -111,16 +110,3 @@ class NeonSkillManager(SkillManager):
         LOG.info(f"All configured ready settings met: {ready_services}")
         self.bus.emit(Message("mycroft.ready", context={"source": ["skills"], "destination": valid_services}))
 
-    # Override to maintain skill load support
-    def handle_initial_training(self, message):
-        """
-        This method blocks `run` until network and internet skills are loaded
-        (if configured). After `self.initial_load_complete` is set to True,
-        the skills service will be marked as ready
-        """
-        LOG.debug(f"Handling message: {message.msg_type}")
-        # Wait for network and internet skills to load as configured
-        if not self._wait_until_skills_ready():
-            LOG.error("Skills did not report ready. Continuing anyway.")
-        self.initial_load_complete = True
-            

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -28,6 +28,7 @@
 
 from os import makedirs
 from os.path import isdir, join, expanduser
+from threading import Thread
 from ovos_utils.xdg_utils import xdg_data_home
 from ovos_utils.log import LOG
 from ovos_bus_client.message import Message
@@ -43,6 +44,12 @@ class NeonSkillManager(SkillManager):
         SkillManager._sync_skill_loading_state(self)
         LOG.info("Waiting for skill ready settings")  # TODO Log is only for debugging
         self._wait_until_skills_ready()
+
+        # Start a background thread to check for configured ready settings
+        # while allowing the skills service to continue initialization
+        ready_event_thread = Thread(target=self._check_device_ready)
+        ready_event_thread.daemon = True
+        ready_event_thread.start()
 
     def get_default_skills_dir(self):
         """
@@ -90,7 +97,7 @@ class NeonSkillManager(SkillManager):
             if not self._internet_loaded.wait(self._network_skill_timeout):
                 LOG.error("Timeout waiting for internet skills to load")
                 return False
-        LOG.info(f"Configured ready settings met: {ready_settings}")
+        LOG.info(f"Configured skill load conditions met")
         return True
 
     def _check_device_ready(self):

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -35,6 +35,9 @@ from ovos_core.skill_manager import SkillManager
 
 
 class NeonSkillManager(SkillManager):
+    def _define_message_bus_events(self):
+        # Overriding to use overridden handlers in this class
+        SkillManager._define_message_bus_events(self)
 
     def get_default_skills_dir(self):
         """
@@ -86,7 +89,7 @@ class NeonSkillManager(SkillManager):
             if not self._internet_loaded.wait(self._internet_skill_timeout):
                 LOG.error("Timeout waiting for internet skills to load")
                 return False
-        LOG.info(f"Configured  ready settings met: {ready_settings}")
+        LOG.info(f"Configured ready settings met: {ready_settings}")
         return True
 
     def _check_device_ready(self):
@@ -113,6 +116,7 @@ class NeonSkillManager(SkillManager):
         (if configured). After `self.initial_load_complete` is set to True,
         the skills service will be marked as ready
         """
+        LOG.debug(f"Handling message: {message.msg_type}")
         # Wait for network and internet skills to load as configured
         if not self._wait_until_skills_ready():
             LOG.error("Skills did not report ready. Continuing anyway.")

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -97,7 +97,7 @@ class NeonSkillManager(SkillManager):
             if not self._internet_loaded.wait(self._network_skill_timeout):
                 LOG.error("Timeout waiting for internet skills to load")
                 return False
-        LOG.info(f"Configured skill load conditions met")
+        LOG.debug("Configured skill load conditions met")
         return True
 
     def _check_device_ready(self):
@@ -106,14 +106,17 @@ class NeonSkillManager(SkillManager):
         ready_settings = self.config.get("ready_settings", ["skills"])
         valid_services = ("skills", "voice", "audio", "gui_service", "internet")
         ready_services = {s: False for s in ready_settings if s in valid_services}
+        LOG.info(f"Waiting for services: {ready_services}")
         while not all(ready_services.values()):
             for service in ready_services:
                 if not ready_services[service]:
                     resp = self.bus.wait_for_response(Message(f"mycroft.{service}.is_ready", context={"source": ["skills"], "destination": [service]}))
+                    LOG.info(resp)  # TODO: Log to be downgraded to debug
                     service_ready = resp and resp.data.get("status") == "ready"
                     if service_ready:
                         LOG.info(f"{service} reports ready")
                         ready_services[service] = service_ready
+            LOG.info(f"Services ready: {ready_services}")  # TODO: Log to be downgraded to debug
         LOG.info(f"All configured ready settings met: {ready_services}")
         self.bus.emit(Message("mycroft.ready", context={"source": ["skills"], "destination": valid_services}))
 

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -30,7 +30,7 @@ from os import makedirs
 from os.path import isdir, join, expanduser
 from threading import Thread
 from ovos_utils.xdg_utils import xdg_data_home
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 from ovos_bus_client.message import Message
 from ovos_core.skill_manager import SkillManager
 
@@ -53,6 +53,8 @@ class NeonSkillManager(SkillManager):
         ready_event_thread.daemon = True
         ready_event_thread.start()
 
+    @deprecated("Legacy skills are deprecated and this method should not "
+                "be used.", "25.10.1")
     def get_default_skills_dir(self):
         """
         Go through legacy config params to locate the default skill directory

--- a/neon_core/skills/skill_manager.py
+++ b/neon_core/skills/skill_manager.py
@@ -30,7 +30,7 @@ from os import makedirs
 from os.path import isdir, join, expanduser
 from ovos_utils.xdg_utils import xdg_data_home
 from ovos_utils.log import LOG
-
+from ovos_bus_client.message import Message
 from ovos_core.skill_manager import SkillManager
 
 
@@ -71,10 +71,50 @@ class NeonSkillManager(SkillManager):
             LOG.debug("Ignoring request not to bind bus")
         return SkillManager._get_plugin_skill_loader(self, skill_id, True)
 
-    def run(self):
-        """Load skills and update periodically from disk and internet."""
-        from os import environ
-        environ.setdefault('OVOS_CONFIG_BASE_FOLDER', "neon")
-        environ.setdefault('OVOS_CONFIG_FILENAME', "neon.yaml")
-        LOG.debug("set default configuration to `neon/neon.yaml`")
-        SkillManager.run(self)
+    # Re-implement support for internet and network skill load
+    def _wait_until_skills_ready(self):
+        """
+        Block until configured network and internet skills are loaded to
+        delay skills service reporting ready.
+        """
+        ready_settings = self.config.get("ready_settings", ["skills"])
+        if "network_skills" in ready_settings:
+            if not self._network_loaded.wait(self._network_skill_timeout):
+                LOG.error("Timeout waiting for network skills to load")
+                return False
+        if "internet_skills" in ready_settings:
+            if not self._internet_loaded.wait(self._internet_skill_timeout):
+                LOG.error("Timeout waiting for internet skills to load")
+                return False
+        LOG.info(f"Configured  ready settings met: {ready_settings}")
+        return True
+
+    def _check_device_ready(self):
+        while not self._wait_until_skills_ready():
+            LOG.warning("Skills not ready, still waiting...")
+        ready_settings = self.config.get("ready_settings", ["skills"])
+        valid_services = ("skills", "voice", "audio", "gui_service", "internet")
+        ready_services = {s: False for s in ready_settings if s in valid_services}
+        while not all(ready_services.values()):
+            for service in ready_services:
+                if not ready_services[service]:
+                    resp = self.bus.wait_for_response(Message(f"mycroft.{service}.is_ready", context={"source": ["skills"], "destination": [service]}))
+                    service_ready = resp and resp.data.get("status") == "ready"
+                    if service_ready:
+                        LOG.info(f"{service} reports ready")
+                        ready_services[service] = service_ready
+        LOG.info(f"All configured ready settings met: {ready_services}")
+        self.bus.emit(Message("mycroft.ready", context={"source": ["skills"], "destination": valid_services}))
+
+    # Override to maintain skill load support
+    def handle_initial_training(self, message):
+        """
+        This method blocks `run` until network and internet skills are loaded
+        (if configured). After `self.initial_load_complete` is set to True,
+        the skills service will be marked as ready
+        """
+        # Wait for network and internet skills to load as configured
+        if not self._wait_until_skills_ready():
+            LOG.error("Skills did not report ready. Continuing anyway.")
+        self.initial_load_complete = True
+            

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,4 @@
-# ovos-core version pinned for compat. with patches in NeonCore
-ovos-core[lgpl]~=0.1
+ovos-core[lgpl]~=0.2
 
 
 neon-utils[network]~=1.13,>=1.13.1a4

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -37,8 +37,6 @@ class ConfigurationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         os.environ["XDG_CONFIG_HOME"] = cls.CONFIG_PATH
-        os.environ["OVOS_CONFIG_BASE_FOLDER"] = "neon"
-        os.environ["OVOS_CONFIG_FILENAME"] = "neon.yaml"
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/test/test_skills_module.py
+++ b/test/test_skills_module.py
@@ -32,12 +32,12 @@ import sys
 import unittest
 import wave
 
+from pytest import mark
+from mock import Mock, patch
 from copy import deepcopy
 from os.path import join, dirname, expanduser, isdir
 from threading import Event
 from time import time
-
-from unittest.mock import Mock, patch
 from ovos_bus_client import Message
 from ovos_utils.messagebus import FakeBus
 from ovos_utils.xdg_utils import xdg_data_home
@@ -357,12 +357,7 @@ class TestSkillManager(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        #from neon_core.util.runtime_utils import use_neon_core
-        #from neon_utils.configuration_utils import init_config_dir
         os.environ["XDG_CONFIG_HOME"] = cls.config_dir
-        os.environ["OVOS_CONFIG_BASE_FOLDER"] = "neon"
-        os.environ["OVOS_CONFIG_FILENAME"] = "neon.yaml"
-        #use_neon_core(init_config_dir)()
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -372,6 +367,7 @@ class TestSkillManager(unittest.TestCase):
         if os.path.isdir(cls.config_dir):
             shutil.rmtree(cls.config_dir)
 
+    @mark.skip("Skill directory handling is deprecated")
     @patch("ovos_core.skill_manager.SkillManager.run")
     def test_get_default_skills_dir(self, _):
         from neon_core.skills.skill_manager import NeonSkillManager
@@ -409,6 +405,41 @@ class TestSkillManager(unittest.TestCase):
         default_dir = manager.get_default_skills_dir()
         self.assertEqual(default_dir, expanduser('~/neon-skills'))
         self.assertTrue(isdir(expanduser("~/neon-skills")))
+
+    def test_wait_until_skills_ready(self):
+        from neon_core.skills.skill_manager import NeonSkillManager
+        manager = NeonSkillManager(FakeBus())
+        manager._network_skill_timeout = 1
+
+        # No ready settings is ready
+        manager.config['ready_settings'] = []
+        self.assertTrue(manager._wait_until_skills_ready())
+
+        # Check network skills not ready
+        manager.config['ready_settings'] = ['network_skills']
+        self.assertFalse(manager._wait_until_skills_ready())
+
+        # Check internet skills not ready
+        manager.config['ready_settings'].append('internet_skills')
+        self.assertFalse(manager._wait_until_skills_ready())
+
+        # Check skills are loaded
+        manager._network_loaded.set()
+        manager._internet_loaded.set()
+        self.assertTrue(manager._wait_until_skills_ready())
+
+    def test_check_device_ready(self):
+        from neon_core.skills.skill_manager import NeonSkillManager
+        manager = NeonSkillManager(FakeBus())
+
+        on_ready = Mock()
+        manager.bus.on("mycroft.ready", on_ready)
+
+        # No services to wait for
+        manager.config['ready_settings'] = []
+        manager._check_device_ready()
+        on_ready.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_skills_module.py
+++ b/test/test_skills_module.py
@@ -67,8 +67,6 @@ class TestSkillService(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         os.environ["XDG_CONFIG_HOME"] = cls.config_dir
-        os.environ["OVOS_CONFIG_BASE_FOLDER"] = "neon"
-        os.environ["OVOS_CONFIG_FILENAME"] = "neon.yaml"
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -184,8 +182,6 @@ class TestIntentService(unittest.TestCase):
         import neon_core
 
         os.environ["XDG_CONFIG_HOME"] = cls.test_config_dir
-        os.environ["OVOS_CONFIG_BASE_FOLDER"] = "neon"
-        os.environ["OVOS_CONFIG_FILENAME"] = "neon.yaml"
         import ovos_config
         import importlib
         importlib.reload(ovos_config.meta)
@@ -209,8 +205,6 @@ class TestIntentService(unittest.TestCase):
     def tearDownClass(cls) -> None:
         cls.intent_service.shutdown()
         os.environ.pop("XDG_CONFIG_HOME")
-        os.environ.pop("OVOS_CONFIG_BASE_FOLDER")
-        os.environ.pop("OVOS_CONFIG_FILENAME")
         shutil.rmtree(cls.test_config_dir)
 
     def test_save_utterance_transcription(self):
@@ -362,8 +356,6 @@ class TestSkillManager(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         os.environ.pop("XDG_CONFIG_HOME")
-        os.environ.pop("OVOS_CONFIG_BASE_FOLDER")
-        os.environ.pop("OVOS_CONFIG_FILENAME")
         if os.path.isdir(cls.config_dir):
             shutil.rmtree(cls.config_dir)
 


### PR DESCRIPTION
# Description
Refactors configuration envvars to be set earlier in the service load process
Implements new logic to handle service readiness checks which support ovos-core 0.2+
Updates unit tests to cover changes to NeonSkillManager

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Includes clean up of config envvars in test cases