### PR TITLE
Update default STT config

### DIFF
--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -20,7 +20,6 @@ stt:
   ovos-stt-plugin-server:
     urls:
     - https://whisper.neonaiservices.com/stt
-    - https://whisper.tigregotico.pt/stt
     - https://stt.smartgic.io/fasterwhisper/stt
 tts:
   pulse_duck: false

--- a/neon_core/configuration/neon.yaml
+++ b/neon_core/configuration/neon.yaml
@@ -18,7 +18,10 @@ stt:
   ovos-stt-plugin-vosk:
     model: /home/neon/.local/share/neon/vosk-model-small-en-us-0.15
   ovos-stt-plugin-server:
-    url: https://whisper.neonaiservices.com/stt
+    urls:
+    - https://whisper.neonaiservices.com/stt
+    - https://whisper.tigregotico.pt/stt
+    - https://stt.smartgic.io/fasterwhisper/stt
 tts:
   pulse_duck: false
   preload_fallback: false

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -22,7 +22,7 @@ neon-stt-plugin-google-cloud-streaming~=2.0
 neon-tts-plugin-coqui-remote~=0.1
 neon-stt-plugin-nemo~=0.1
 ovos-tts-plugin-server~=0.0.2
-ovos-stt-plugin-server~=0.0.3
+ovos-stt-plugin-server~=0.1
 ovos-tts-plugin-piper~=0.0.2
 
 # Fallback plugins


### PR DESCRIPTION
# Description
Update STT default config to include other public servers (only if Neon server request fails)
Updates `ovos-stt-plugin-server` dependency to allow latest version

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->